### PR TITLE
Replace syntax highlighting styles in base.css to use SyntaxHighlighter instead of Pygments

### DIFF
--- a/themes/jquery/css/base.css
+++ b/themes/jquery/css/base.css
@@ -255,81 +255,326 @@
 {	border: 1px solid #bfbfbf;
 	padding: 1px; }
 
-	/*
-	 * Pygments style: Tango
-	 * TODO: Improve
-	 */
-	.highlightblock { margin: 1em 0; width: 100%; overflow: auto; border: 1px solid #ccc; background: #f8f8f8; }
-	.highlighttable .linenodiv pre, .highlight pre { padding: .5em; }
-	.highlighttable .linenodiv pre { border-right: 1px solid #ccc; background: #fff; }
-	.highlight .c { color: #8f5902; font-style: italic } /* Comment */
-	.highlight .err { color: #a40000; border: 1px solid #ef2929 } /* Error */
-	.highlight .g { color: #000000 } /* Generic */
-	.highlight .k { color: #204a87; font-weight: bold } /* Keyword */
-	.highlight .l { color: #000000 } /* Literal */
-	.highlight .n { color: #000000 } /* Name */
-	.highlight .o { color: #ce5c00; font-weight: bold } /* Operator */
-	.highlight .x { color: #000000 } /* Other */
-	.highlight .p { color: #000000; font-weight: bold } /* Punctuation */
-	.highlight .cm { color: #8f5902; font-style: italic } /* Comment.Multiline */
-	.highlight .cp { color: #8f5902; font-style: italic } /* Comment.Preproc */
-	.highlight .c1 { color: #8f5902; font-style: italic } /* Comment.Single */
-	.highlight .cs { color: #8f5902; font-style: italic } /* Comment.Special */
-	.highlight .gd { color: #a40000 } /* Generic.Deleted */
-	.highlight .ge { color: #000000; font-style: italic } /* Generic.Emph */
-	.highlight .gr { color: #ef2929 } /* Generic.Error */
-	.highlight .gh { color: #000080; font-weight: bold } /* Generic.Heading */
-	.highlight .gi { color: #00A000 } /* Generic.Inserted */
-	.highlight .go { color: #000000; font-style: italic } /* Generic.Output */
-	.highlight .gp { color: #8f5902 } /* Generic.Prompt */
-	.highlight .gs { color: #000000; font-weight: bold } /* Generic.Strong */
-	.highlight .gu { color: #800080; font-weight: bold } /* Generic.Subheading */
-	.highlight .gt { color: #a40000; font-weight: bold } /* Generic.Traceback */
-	.highlight .kc { color: #204a87; font-weight: bold } /* Keyword.Constant */
-	.highlight .kd { color: #204a87; font-weight: bold } /* Keyword.Declaration */
-	.highlight .kn { color: #204a87; font-weight: bold } /* Keyword.Namespace */
-	.highlight .kp { color: #204a87; font-weight: bold } /* Keyword.Pseudo */
-	.highlight .kr { color: #204a87; font-weight: bold } /* Keyword.Reserved */
-	.highlight .kt { color: #204a87; font-weight: bold } /* Keyword.Type */
-	.highlight .ld { color: #000000 } /* Literal.Date */
-	.highlight .m { color: #0000cf; font-weight: bold } /* Literal.Number */
-	.highlight .s { color: #4e9a06 } /* Literal.String */
-	.highlight .na { color: #c4a000 } /* Name.Attribute */
-	.highlight .nb { color: #204a87 } /* Name.Builtin */
-	.highlight .nc { color: #000000 } /* Name.Class */
-	.highlight .no { color: #000000 } /* Name.Constant */
-	.highlight .nd { color: #5c35cc; font-weight: bold } /* Name.Decorator */
-	.highlight .ni { color: #ce5c00 } /* Name.Entity */
-	.highlight .ne { color: #cc0000; font-weight: bold } /* Name.Exception */
-	.highlight .nf { color: #000000 } /* Name.Function */
-	.highlight .nl { color: #f57900 } /* Name.Label */
-	.highlight .nn { color: #000000 } /* Name.Namespace */
-	.highlight .nx { color: #000000 } /* Name.Other */
-	.highlight .py { color: #000000 } /* Name.Property */
-	.highlight .nt { color: #204a87; font-weight: bold } /* Name.Tag */
-	.highlight .nv { color: #000000 } /* Name.Variable */
-	.highlight .ow { color: #204a87; font-weight: bold } /* Operator.Word */
-	.highlight .w { color: #f8f8f8; text-decoration: underline } /* Text.Whitespace */
-	.highlight .mf { color: #0000cf; font-weight: bold } /* Literal.Number.Float */
-	.highlight .mh { color: #0000cf; font-weight: bold } /* Literal.Number.Hex */
-	.highlight .mi { color: #0000cf; font-weight: bold } /* Literal.Number.Integer */
-	.highlight .mo { color: #0000cf; font-weight: bold } /* Literal.Number.Oct */
-	.highlight .sb { color: #4e9a06 } /* Literal.String.Backtick */
-	.highlight .sc { color: #4e9a06 } /* Literal.String.Char */
-	.highlight .sd { color: #8f5902; font-style: italic } /* Literal.String.Doc */
-	.highlight .s2 { color: #4e9a06 } /* Literal.String.Double */
-	.highlight .se { color: #4e9a06 } /* Literal.String.Escape */
-	.highlight .sh { color: #4e9a06 } /* Literal.String.Heredoc */
-	.highlight .si { color: #4e9a06 } /* Literal.String.Interpol */
-	.highlight .sx { color: #4e9a06 } /* Literal.String.Other */
-	.highlight .sr { color: #4e9a06 } /* Literal.String.Regex */
-	.highlight .s1 { color: #4e9a06 } /* Literal.String.Single */
-	.highlight .ss { color: #4e9a06 } /* Literal.String.Symbol */
-	.highlight .bp { color: #3465a4 } /* Name.Builtin.Pseudo */
-	.highlight .vc { color: #000000 } /* Name.Variable.Class */
-	.highlight .vg { color: #000000 } /* Name.Variable.Global */
-	.highlight .vi { color: #000000 } /* Name.Variable.Instance */
-	.highlight .il { color: #0000cf; font-weight: bold } /* Literal.Number.Integer.Long */
+	.syntaxhighlighter {
+	padding: 1em 0;
+	}
+		/*******************************************************************************/
+		/* Syntax Highlighting*/
+		/* Core Styles */
+		/* https://github.com/alexgorbatchev/SyntaxHighlighter/blob/master/styles/shCoreDefault.css */
+		/*******************************************************************************/
+		.syntaxhighlighter a,
+		.syntaxhighlighter div,
+		.syntaxhighlighter code,
+		.syntaxhighlighter table,
+		.syntaxhighlighter table td,
+		.syntaxhighlighter table tr,
+		.syntaxhighlighter table tbody,
+		.syntaxhighlighter table thead,
+		.syntaxhighlighter table caption,
+		.syntaxhighlighter textarea {
+			-moz-border-radius: 0 0 0 0 !important;
+			-webkit-border-radius: 0 0 0 0 !important;
+			background: none !important;
+			border: 0 !important;
+			bottom: auto !important;
+			float: none !important;
+			height: auto !important;
+			left: auto !important;
+			line-height: 1.1em !important;
+			margin: 0 !important;
+			outline: 0 !important;
+			overflow: visible !important;
+			padding: 0 !important;
+			position: static !important;
+			right: auto !important;
+			text-align: left !important;
+			top: auto !important;
+			vertical-align: baseline !important;
+			width: auto !important;
+			box-sizing: content-box !important;
+			font-family: "Consolas", "Bitstream Vera Sans Mono", "Courier New", Courier, monospace !important;
+			font-weight: normal !important;
+			font-style: normal !important;
+			font-size: 1em !important;
+			min-height: inherit !important;
+			min-height: auto !important;
+		}
+
+		.syntaxhighlighter {
+			width: 100% !important;
+			margin: 1em 0 1em 0 !important;
+			position: relative !important;
+			overflow: auto !important;
+			font-size: 1em !important;
+		}
+		.syntaxhighlighter.source {
+			overflow: hidden !important;
+		}
+		.syntaxhighlighter .bold {
+			font-weight: bold !important;
+		}
+		.syntaxhighlighter .italic {
+			font-style: italic !important;
+		}
+		.syntaxhighlighter .line {
+			white-space: pre !important;
+		}
+		.syntaxhighlighter table {
+			width: 100% !important;
+		}
+		.syntaxhighlighter table caption {
+			text-align: left !important;
+			padding: .5em 0 0.5em 1em !important;
+		}
+		.syntaxhighlighter table td.code {
+			width: 100% !important;
+		}
+		.syntaxhighlighter table td.code .container {
+			position: relative !important;
+		}
+		.syntaxhighlighter table td.code .container textarea {
+			box-sizing: border-box !important;
+			position: absolute !important;
+			left: 0 !important;
+			top: 0 !important;
+			width: 100% !important;
+			height: 100% !important;
+			border: none !important;
+			background: white !important;
+			padding-left: 1em !important;
+			overflow: hidden !important;
+			white-space: pre !important;
+		}
+		.syntaxhighlighter table td.gutter .line {
+			text-align: right !important;
+			padding: 0 0.5em 0 1em !important;
+		}
+		.syntaxhighlighter table td.code .line {
+			padding: 0 1em !important;
+		}
+		.syntaxhighlighter.nogutter td.code .container textarea, .syntaxhighlighter.nogutter td.code .line {
+			padding-left: 0em !important;
+		}
+		.syntaxhighlighter.show {
+			display: block !important;
+		}
+		.syntaxhighlighter.collapsed table {
+			display: none !important;
+		}
+		.syntaxhighlighter.collapsed .toolbar {
+			padding: 0.1em 0.8em 0em 0.8em !important;
+			font-size: 1em !important;
+			position: static !important;
+			width: auto !important;
+			height: auto !important;
+		}
+		.syntaxhighlighter.collapsed .toolbar span {
+			display: inline !important;
+			margin-right: 1em !important;
+		}
+		.syntaxhighlighter.collapsed .toolbar span a {
+			padding: 0 !important;
+			display: none !important;
+		}
+		.syntaxhighlighter.collapsed .toolbar span a.expandSource {
+			display: inline !important;
+		}
+		.syntaxhighlighter .toolbar {
+			position: absolute !important;
+			right: 1px !important;
+			top: 1px !important;
+			width: 11px !important;
+			height: 11px !important;
+			font-size: 10px !important;
+			z-index: 10 !important;
+		}
+		.syntaxhighlighter .toolbar span.title {
+			display: inline !important;
+		}
+		.syntaxhighlighter .toolbar a {
+			display: block !important;
+			text-align: center !important;
+			text-decoration: none !important;
+			padding-top: 1px !important;
+		}
+		.syntaxhighlighter .toolbar a.expandSource {
+			display: none !important;
+		}
+		.syntaxhighlighter.ie {
+			font-size: .9em !important;
+			padding: 1px 0 1px 0 !important;
+		}
+		.syntaxhighlighter.ie .toolbar {
+			line-height: 8px !important;
+		}
+		.syntaxhighlighter.ie .toolbar a {
+			padding-top: 0px !important;
+		}
+		.syntaxhighlighter.printing .line.alt1 .content,
+		.syntaxhighlighter.printing .line.alt2 .content,
+		.syntaxhighlighter.printing .line.highlighted .number,
+		.syntaxhighlighter.printing .line.highlighted.alt1 .content,
+		.syntaxhighlighter.printing .line.highlighted.alt2 .content {
+			background: none !important;
+		}
+		.syntaxhighlighter.printing .line .number {
+			color: #bbbbbb !important;
+		}
+		.syntaxhighlighter.printing .line .content {
+			color: black !important;
+		}
+		.syntaxhighlighter.printing .toolbar {
+			display: none !important;
+		}
+		.syntaxhighlighter.printing a {
+			text-decoration: none !important;
+		}
+		.syntaxhighlighter.printing .plain, .syntaxhighlighter.printing .plain a {
+			color: black !important;
+		}
+		.syntaxhighlighter.printing .comments, .syntaxhighlighter.printing .comments a {
+			color: #008200 !important;
+		}
+		.syntaxhighlighter.printing .string, .syntaxhighlighter.printing .string a {
+			color: blue !important;
+		}
+		.syntaxhighlighter.printing .keyword {
+			color: #006699 !important;
+			font-weight: bold !important;
+		}
+		.syntaxhighlighter.printing .preprocessor {
+			color: gray !important;
+		}
+		.syntaxhighlighter.printing .variable {
+			color: #aa7700 !important;
+		}
+		.syntaxhighlighter.printing .value {
+			color: #009900 !important;
+		}
+		.syntaxhighlighter.printing .functions {
+			color: #ff1493 !important;
+		}
+		.syntaxhighlighter.printing .constants {
+			color: #0066cc !important;
+		}
+		.syntaxhighlighter.printing .script {
+			font-weight: bold !important;
+		}
+		.syntaxhighlighter.printing .color1, .syntaxhighlighter.printing .color1 a {
+			color: gray !important;
+		}
+		.syntaxhighlighter.printing .color2, .syntaxhighlighter.printing .color2 a {
+			color: #ff1493 !important;
+		}
+		.syntaxhighlighter.printing .color3, .syntaxhighlighter.printing .color3 a {
+			color: red !important;
+		}
+		.syntaxhighlighter.printing .break, .syntaxhighlighter.printing .break a {
+			color: black !important;
+		}
+
+		.syntaxhighlighter {
+			background-color: white !important;
+		}
+		.syntaxhighlighter .line.alt1 {
+			background-color: white !important;
+		}
+		.syntaxhighlighter .line.alt2 {
+			background-color: white !important;
+		}
+		.syntaxhighlighter .line.highlighted.alt1, .syntaxhighlighter .line.highlighted.alt2 {
+			background-color: #e0e0e0 !important;
+		}
+		.syntaxhighlighter .line.highlighted.number {
+			color: black !important;
+		}
+		.syntaxhighlighter table caption {
+			color: black !important;
+		}
+		.syntaxhighlighter .gutter {
+			color: #afafaf !important;
+		}
+		.syntaxhighlighter .gutter .line {
+			border-right: 3px solid #6ce26c !important;
+		}
+		.syntaxhighlighter .gutter .line.highlighted {
+			background-color: #6ce26c !important;
+			color: white !important;
+		}
+		.syntaxhighlighter.printing .line .content {
+			border: none !important;
+		}
+		.syntaxhighlighter.collapsed {
+			overflow: visible !important;
+		}
+		.syntaxhighlighter.collapsed .toolbar {
+			color: blue !important;
+			background: white !important;
+			border: 1px solid #6ce26c !important;
+		}
+		.syntaxhighlighter.collapsed .toolbar a {
+			color: blue !important;
+		}
+		.syntaxhighlighter.collapsed .toolbar a:hover {
+			color: red !important;
+		}
+		.syntaxhighlighter .toolbar {
+			color: white !important;
+			background: #6ce26c !important;
+			border: none !important;
+		}
+		.syntaxhighlighter .toolbar a {
+			color: white !important;
+		}
+		.syntaxhighlighter .toolbar a:hover {
+			color: black !important;
+		}
+		.syntaxhighlighter .plain, .syntaxhighlighter .plain a {
+			color: black !important;
+		}
+		.syntaxhighlighter .comments, .syntaxhighlighter .comments a {
+			color: #008200 !important;
+		}
+		.syntaxhighlighter .string, .syntaxhighlighter .string a {
+			color: blue !important;
+		}
+		.syntaxhighlighter .keyword {
+			color: #006699 !important;
+		}
+		.syntaxhighlighter .preprocessor {
+			color: gray !important;
+		}
+		.syntaxhighlighter .variable {
+			color: #aa7700 !important;
+		}
+		.syntaxhighlighter .value {
+			color: #009900 !important;
+		}
+		.syntaxhighlighter .functions {
+			color: #ff1493 !important;
+		}
+		.syntaxhighlighter .constants {
+			color: #0066cc !important;
+		}
+		.syntaxhighlighter .script {
+			font-weight: bold !important;
+			color: #006699 !important;
+			background-color: none !important;
+		}
+		.syntaxhighlighter .color1, .syntaxhighlighter .color1 a {
+			color: gray !important;
+		}
+		.syntaxhighlighter .color2, .syntaxhighlighter .color2 a {
+			color: #ff1493 !important;
+		}
+		.syntaxhighlighter .color3, .syntaxhighlighter .color3 a {
+			color: red !important;
+		}
+
+		.syntaxhighlighter .keyword {
+			font-weight: bold !important;
+		}
 
 	/*******************************************************************************/
 	/* Titles */


### PR DESCRIPTION
This PR tracks along with [this PR](https://github.com/jzaefferer/grunt-jquery-content/pull/4) on grunt-jquery-content, which replaces Pygments with node-syntaxhighlighter. Once that issue has been merged, we'll need to pull in these CSS changes so the highlighted code blocks display properly.
