### PR TITLE
Remove links to Tutorials page in header and footer of jQuery.com 

### DIFF
--- a/themes/jquery.com/footer.php
+++ b/themes/jquery.com/footer.php
@@ -13,7 +13,6 @@
 						<li class="jq-download jq-first"><a href="http://docs.jquery.com/Downloading_jQuery">Download</a></li>
 						<li class="jq-documentation"><a href="http://docs.jquery.com">Documentation</a></li>
 
-						<li class="jq-tutorials"><a href="http://docs.jquery.com/Tutorials">Tutorials</a></li>
 						<li class="jq-bugTracker"><a href="http://dev.jquery.com/">Bug Tracker</a></li>
 						<li class="jq-discussion jq-last"><a href="http://docs.jquery.com/Discussion">Discussion</a></li>
 					</ul>

--- a/themes/jquery.com/header.php
+++ b/themes/jquery.com/header.php
@@ -36,7 +36,6 @@
 						<li class="jq-download jq-first"><a href="http://jquery.com/download/">Download</a></li>
 
 						<li class="jq-documentation"><a href="http://docs.jquery.com/">Documentation</a></li>
-						<li class="jq-tutorials"><a href="http://docs.jquery.com/Tutorials">Tutorials</a></li>
 						<li class="jq-bugTracker"><a href="http://bugs.jquery.com/">Bug Tracker</a></li>
 						<li class="jq-discussion jq-last"><a href="http://docs.jquery.com/Discussion">Discussion</a></li>
 					</ul>


### PR DESCRIPTION
This accompanies https://github.com/jquery/jquery.com/pull/5
