### PR TITLE
Permit download links to wrap

### DIFF
--- a/themes/jquery/css/base.css
+++ b/themes/jquery/css/base.css
@@ -2717,6 +2717,8 @@ html.jquery-learning { background: #000 url(../i/learning_bg.jpg) no-repeat cent
 	#site-footer .footer-icon-links li br { display: none; }
 
 	#site-footer .constrain { padding: 0; }
+	
+	#site-footer .download > span { white-space: normal }
 
 	#site-footer h3,
 	#site-footer h3:after {


### PR DESCRIPTION
When the layout is 320 pixels wide the "Download Builder →" causes the parent SPAN to be too wide. Screenshot: http://i.imgur.com/YrPff.png
