### PR TITLE
Base jQuery Parent Theme: Removes unnecessary elements

### DIFF
--- a/themes/jquery/content-page.php
+++ b/themes/jquery/content-page.php
@@ -5,17 +5,7 @@
 ?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
-	<?php if ( !count( get_post_meta( $post->ID, "hide_title" ) ) ) : ?>
-		<header class="entry-header">
-			<h1 class="entry-title"><?php the_title(); ?></h1>
-		</header><!-- .entry-header -->
-	<?php endif; ?>
-
 	<div class="entry-content">
 		<?php the_content(); ?>
-		<?php wp_link_pages( array( 'before' => '<div class="page-link"><span>' . __( 'Pages:', 'twentyeleven' ) . '</span>', 'after' => '</div>' ) ); ?>
 	</div><!-- .entry-content -->
-	<footer class="entry-meta">
-		<?php edit_post_link( __( 'Edit', 'twentyeleven' ), '<span class="edit-link">', '</span>' ); ?>
-	</footer><!-- .entry-meta -->
 </article><!-- #post-<?php the_ID(); ?> -->

--- a/themes/jquery/content-single.php
+++ b/themes/jquery/content-single.php
@@ -6,8 +6,6 @@
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 	<header class="entry-header">
-		<h1 class="entry-title"><?php the_title(); ?></h1>
-
 		<?php if ( 'post' == get_post_type() ) : ?>
 		<div class="entry-meta">
 			<?php twentyeleven_posted_on(); ?>


### PR DESCRIPTION
- Removes footer from pages. Since content is managed by GitHub, these
  links are unnecessary.
- Removes header and auto-generated titles from pages. All content is
  managed by the GitHub Repos.
