### PR TITLE
Added gravatars for plugin authors & maintainers.

### DIFF
--- a/themes/plugins.jquery.com/functions.php
+++ b/themes/plugins.jquery.com/functions.php
@@ -132,16 +132,39 @@ function jq_release_manifest( $id = null ) {
 	return json_decode( get_post_meta( $id, 'manifest', true ) );
 }
 
-function person( $person, $avatar ) {
-	$ret = htmlspecialchars( $person->name );
-	if ( !empty( $person->url ) ) {
+//////////////////////////////////////////////////////////////////////////////
+// Produces a block of markup describing the given person, optionally with
+// a gravatar image at the given size.
+
+function person( $person, $avatar, $size = 96 ) {
+
+	$name = htmlspecialchars( $person->name );
+
+	// If an avatar is requested, build a little gravatar tile; otherwise
+	// just use the name by itself.
+
+	if ( $avatar ) {
+		if (!empty( $person->email )) {
+			$content = get_avatar( $person->email, $size );
+		} else {
+			$content = get_avatar( null, $size );
+		}
+		$content = $content . $name;
+	} else {
+		$content = $name;
+	}
+
+	// Wrap the content in a link to the person's page or email address
+
+	if (!empty( $person->url )) {
 		$url = htmlspecialchars( $person->url );
-		$ret = "<a href='$url'>$ret</a>";
+		return "<a href='$url'>$content</a>";
+	} elseif (!empty( $person->email )) {
+		$email = htmlspecialchars( $person->email );
+		return "<a href='mailto:$email'>$content</a>";
+	} else {
+		return $content;
 	}
-	if ( $avatar && !empty( $person->email ) ) {
-		$ret = get_avatar( $person->email, '80' ) . $ret;
-	}
-	return $ret;
 }
 
 function jq_release_download_url() {
@@ -184,7 +207,7 @@ function jq_release_licenses() {
 	return $ret;
 }
 
-function jq_release_maintainers( $options = array('avatar' => false) ) {
+function jq_release_maintainers( $options = array('avatar' => false, 'size' => 48) ) {
 	$pkg = jq_release_manifest();
 
 	if ( empty( $pkg->maintainers ) ) {
@@ -193,15 +216,15 @@ function jq_release_maintainers( $options = array('avatar' => false) ) {
 
 	$ret = '<ul>';
 	foreach( $pkg->maintainers as $maintainer ) {
-		$ret .= '<li>' . person( $maintainer, $options['avatar'] ) . '</li>';
+		$ret .= '<li>' . person( $maintainer, $options['avatar'], $options['size'] ) . '</li>';
 	}
 	$ret .= '</ul>';
 	return $ret;
 }
 
-function jq_release_author( $options = array('avatar' => false) ) {
+function jq_release_author( $options = array('avatar' => false, 'size' => 48) ) {
 	$pkg = jq_release_manifest();
-	return person( $pkg->author, $options['avatar'] );
+	return person( $pkg->author, $options['avatar'], $options['size'] );
 }
 
 function jq_release_dependencies() {

--- a/themes/plugins.jquery.com/sidebar-jquery_plugin.php
+++ b/themes/plugins.jquery.com/sidebar-jquery_plugin.php
@@ -51,11 +51,11 @@
 	<div class="block author-info">
 		<h3><span class="icon-user"></span>Author</h3>
 		<ul>
-			<li><?php echo jq_release_author(); ?></li>
+			<li><?php echo jq_release_author(array('avatar' => true, 'size' => 80)); ?></li>
 		</ul>
 	</div> <!-- /.author-info -->
 
-	<?php if ( $maintainers = jq_release_maintainers() ) { ?>
+	<?php if ( $maintainers = jq_release_maintainers(array('avatar' => true, 'size' => 48)) ) { ?>
 	<div class="block maintainer-info">
 		<h3><span class="icon-wrench"></span>Maintainers</h3>
 		<?php echo $maintainers; ?>

--- a/themes/plugins.jquery.com/style.css
+++ b/themes/plugins.jquery.com/style.css
@@ -390,6 +390,28 @@ p.info {
 	letter-spacing: 1px;
 }
 
+#sidebar.jquery-plugin .author-info li {
+	background: none;
+	font-size: 18px;
+}
+
+#sidebar.jquery-plugin .maintainer-info li {
+	background: none;
+	font-size: 16px;
+}
+
+#sidebar.jquery-plugin .avatar {
+	margin-right: 10px;
+}
+
+#sidebar.jquery-plugin .avatar-80 {
+	border-radius: 8px;
+}
+
+#sidebar.jquery-plugin .avatar-48 {
+	border-radius: 4px;
+}
+
 /*----------[ Individual plugin page sidebar toolbox ]----------------------*/
 
 .jquery-plugin .toolbox {


### PR DESCRIPTION
I've replaced the plugin author and list of maintainers with gravatar tiles, using the email field of their manifest entries.  If the email has no associated gravatar, the standard 'unknown person' image is used instead.

This closes jquery/plugins.jquery.com#39.
