### PR TITLE
Updates CDN jQuery from 1.4.2 to 1.8.3.

### DIFF
--- a/themes/jquery.com/header.php
+++ b/themes/jquery.com/header.php
@@ -5,8 +5,8 @@
 		<title>jQuery: The Write Less, Do More, JavaScript Library</title>
 		<link rel="stylesheet" href="http://static.jquery.com/files/rocker/css/reset.css" type="text/css" />
 		<link rel="stylesheet" href="http://static.jquery.com/files/rocker/css/screen.css" type="text/css" />
-		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
-		<script>!window.jQuery && document.write('<script src="http://code.jquery.com/jquery-1.4.2.min.js"><\/script>');</script>
+		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
+		<script>!window.jQuery && document.write('<script src="http://code.jquery.com/jquery-1.8.3.min.js"><\/script>');</script>
 		<script src="http://static.jquery.com/files/rocker/scripts/custom.js"></script>
 		<link rel="alternate" type="application/rss+xml" title="jQuery Blog" href="http://jquery.com/blog/feed/" />
 		<link rel="shortcut icon" href="http://static.jquery.com/favicon.ico" type="image/x-icon"/>


### PR DESCRIPTION
I finally got a moment to patch this up.

Please be aware I have not tested this locally, as there is quite a bit of setup for a very small change.  I'm hoping that another dev has Wordpress set up to smoke test this change with.  If you prefer, I can go through the full setup detailed in the README to test this myself.
