### PR TITLE
Remove the yellow outline from the search input

### DIFF
--- a/themes/plugins.jquery.com/style.css
+++ b/themes/plugins.jquery.com/style.css
@@ -44,11 +44,7 @@ a {
 	width: 60%;
 	margin: 60px auto 0;
 	font-size: 22px;
-	background-color: #666;
-	border: 1px solid #ccc;
-	-webkit-box-shadow: 0px 0px 8px rgba(0, 0, 0, 0.8);
-	box-shadow: 0px 0px 8px rgba(0, 0, 0, 0.8);
-	border-radius: 2em;
+	padding: 0;
 }
 
 #banner-secondary .searchform input {
@@ -58,7 +54,28 @@ a {
 	border: none;
 	background: none;
 	color: #fff;
-	outline: none;
+	background-color: #666;
+	border: 1px solid #ccc;
+	-webkit-box-shadow: 0px 0px 8px rgba(0, 0, 0, 0.8);
+	-moz-box-shadow: 0px 0px 8px rgba(0, 0, 0, 0.8);
+	box-shadow: 0px 0px 8px rgba(0, 0, 0, 0.8);
+	-webkit-transition: border linear 0.2s, box-shadow linear 0.2s;
+	-moz-transition: border linear 0.2s, box-shadow linear 0.2s;
+	-o-transition: border linear 0.2s, box-shadow linear 0.2s;
+	transition: border linear 0.2s, box-shadow linear 0.2s;
+	border-radius: 2em;
+	padding: 11px 0 11px 40px;
+}
+
+#banner-secondary .searchform input:focus {
+	border-color: rgba(122, 206, 244, 0.8);
+	outline: 0;
+	outline: thin dotted \9;
+	/* IE6-9 */
+	
+	-webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(122, 206, 244, 0.6);
+	-moz-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(122, 206, 244, 0.6);
+	  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(122, 206, 244, 0.6);	
 }
 
 /*


### PR DESCRIPTION
Currently, the search-box at http://plugins.jquery.com does not look very good in Chrome because of the yellow outline.

This tiny change removes it.

![plugins-jquery-com-yellow-outline-search-box](https://f.cloud.github.com/assets/67565/74501/6d3345dc-6094-11e2-8589-5e17f195ffe0.PNG)
