### PR TITLE
Don't wrap button in entry sumary

### DIFF
--- a/themes/plugins.jquery.com/style.css
+++ b/themes/plugins.jquery.com/style.css
@@ -7,6 +7,10 @@ a {
 	color: #0769AD;
 }
 
+#content .entry-summary {
+	clear: both;
+}
+
 #content .entry-summary .button {
 	float: right;
 }


### PR DESCRIPTION
![Screen Shot 2013-01-17 at 10 47 44 AM](https://f.cloud.github.com/assets/52149/75440/c97f7974-60c5-11e2-81e8-ba93ee5b9538.png)
If the plugin doesn't have a description then the button ends up wrapping.
