### PR TITLE
add github contribute link to footer of all qunitjs.com pages

### DIFF
--- a/themes/jquery/footer-qunit.php
+++ b/themes/jquery/footer-qunit.php
@@ -5,6 +5,8 @@
 	<div class="constrain">
 		<div class="row">
 			<div class="six columns centered">
+				<h3><span>Suggestions, Problems, Feedback?</span></h3>
+				<a class="button dark" href="<?php echo jq_get_github_url(); ?>"><i class="icon-github"></i>  Open an Issue or Submit a Pull Request on GitHub</a>
 				<h3><span>Quick Access</span></h3>
 				<div class="cdn">
 					<strong>CDN <em>CSS</em></strong>

--- a/themes/qunitjs.com/style.css
+++ b/themes/qunitjs.com/style.css
@@ -18,3 +18,15 @@ a {
 	border: 1px solid #ccc;
 	border-radius: 5px;
 }
+
+footer .button.dark i{
+	color: #FFF;
+}
+
+footer .button.dark {
+	float: none;
+	width: 80%;
+	display: inline-block;
+	margin-left: 10%;
+	text-align: center;
+}


### PR DESCRIPTION
I've added the "Open an Issue or Submit a Pull Request on GitHub" button to the footer of all qunitjs pages. The footer should look like:
![Screen Shot 2013-01-24 at 10 32 06 AM](https://f.cloud.github.com/assets/475621/93974/72cdaeea-663b-11e2-8154-0f59ae92530d.png)
