### PR TITLE
Extend navigation height to fit the second nav line on mobile.

### DIFF
--- a/themes/jquery/css/base.css
+++ b/themes/jquery/css/base.css
@@ -3148,6 +3148,14 @@ footer li img {
 }
 
 @media only screen and (max-width: 480px) {
+	#global-nav nav {
+		height: 68px;
+	}
+	
+	#global-nav nav ul {
+		border-right: none;
+	}
+	
 	.constrain,
 	#container {
 		padding-left: 10px;


### PR DESCRIPTION
At least a temporary fix for the navigation breaking into two-lines on mobile devices, globally, by extending height of the navigation/nav-background.
