### PR TITLE
Add autofocus attribute to search template

### DIFF
--- a/themes/jquery/searchform.php
+++ b/themes/jquery/searchform.php
@@ -8,6 +8,6 @@
 	<label>
 		<span class="visuallyhidden">Search <?php bloginfo( 'name' ); ?></span>
 		<input type="text" name="s" value="<?php echo get_search_query(); ?>"
-			placeholder="Search <?php bloginfo( 'name' ); ?>">
+			placeholder="Search <?php bloginfo( 'name' ); ?>" autofocus>
 	</label>
 </form>


### PR DESCRIPTION
I think it would increase the usability of any of the jQuery websites with a search widget to have the search input `autofocus` the keyboard input. I did a cursory review of a bunch of the jQuery sites that use the search template, and in every case I looked at, adding `autofocus` would make it easier to search (and there didn't seem to be any existing functionality it would clobber).
