### PR TITLE
add 2.0.0 to quick access in footer

### DIFF
--- a/themes/jquery/footer.php
+++ b/themes/jquery/footer.php
@@ -7,11 +7,15 @@
 			<div class="eight columns">
 				<h3><span>Quick Access</span></h3>
 				<div class="cdn">
-					<strong>CDN</strong>
+					<strong>jQuery 1.x CDN</strong>
 					<input value="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js">
 				</div>
+				<div class="cdn">
+					<strong>jQuery 2.x CDN</strong>
+					<input value="//ajax.googleapis.com/ajax/libs/jquery/2.0.0/jquery.min.js">
+				</div>
 				<div class="download">
-					<strong><a href="http://jquery.com/download/">Download jQuery 1.9.1 →</a></strong>
+					<strong><a href="http://jquery.com/download/">Download jQuery 1.9.1 or 2.0.0 →</a></strong>
 				</div>
 				<ul class="footer-icon-links">
 					<li><a class="icon-github" href="http://github.com/jquery/jquery">GitHub <small>jQuery <br>Source</small></a></li>


### PR DESCRIPTION
Current quick access CDN link is for 1.x. Be nice to have one for 2.x

Also the download button should match the top section download button
