### PR TITLE
jquery.com: Fix broken selector for try-jquery hidpi image

### DIFF
--- a/themes/jquery.com/style.css
+++ b/themes/jquery.com/style.css
@@ -117,15 +117,16 @@ a,
 
 #content li.try-jquery a {
 	background: url('i/try-jquery.jpg') top left no-repeat;
+	background-size: 100%;
 	height: 126px;
 	width: 277px;
 	text-indent: -9999px;
 	display: block;
 }
 
-@media only screen and (-webkit-device-pixel-ratio: 2){
-	#sidebar li.try-jquery a {
-		background: url('i/try-jquery@2x.jpg') top left no-repeat;
+@media only screen and (-webkit-device-pixel-ratio: 2) {
+	#content li.try-jquery a {
+		background-image: url('i/try-jquery@2x.jpg');
 	}
 }
 


### PR DESCRIPTION
Follows-up fefb5a7a30eb3ea148d08652af6336ee6f30cf4e.

The selector was broken, and that was actually a good thing
since there was no background-size rule so the image would've
just be shown twice as big and cropped to the same 126x277px box.
