### PR TITLE
Only apply FontAwesome to ::before and ::after pseudo elements of icon classed elements. Fixes #215 - Unintended icon font in site footer

### DIFF
--- a/themes/jquery/css/base.css
+++ b/themes/jquery/css/base.css
@@ -684,7 +684,6 @@ table {
 
 [class^="icon-"],
 [class*=" icon-"] {
-  font-family: FontAwesome;
   font-weight: normal;
   font-style: normal;
   text-decoration: inherit;
@@ -1192,8 +1191,8 @@ ul.icons li [class*=" icon-"] {
 .icon-folder-open-alt:before      { content: "\f115"; }
 
 /* Manual Font Awesome Styles */
-[class^="icon-"],
-[class*=" icon-"] {
+[class^="icon-"]::before, [class^="icon-"]::after
+[class*=" icon-"]::before, [class*=" icon-"]::after {
   font-family: FontAwesome, "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 


### PR DESCRIPTION
This appears to still work after this change but I have installed FontAwesome locally and still can't get anything to break to see if this actually fixes it. I believe it should be would appreciate if someone who sees the broken version could test it.
