### PR TITLE
All Sites: Never wraps in the middle of words in a <code> block.

### DIFF
--- a/themes/jquery/css/base.css
+++ b/themes/jquery/css/base.css
@@ -238,13 +238,11 @@ pre {
 
 pre, code {
 	white-space: pre;
+	white-space: pre-wrap;
 	word-wrap: break-word;
 	word-spacing: 0;
 	font-size: 13px;
 	line-height: 16px;
-}
-pre {
-	white-space: pre-wrap;
 }
 code {
 	padding: 0 3px;
@@ -255,6 +253,8 @@ pre code {
 	background-color: transparent;
 	font-size: 16px;
 	font-weight: bold;
+	white-space: pre;
+	word-wrap: normal;
 }
 
 /*


### PR DESCRIPTION
`<code>` blocks still wrap, but now words are never broken up. Thanks @gnarf.

![screen shot 2014-01-14 at 11 33 28 am](https://f.cloud.github.com/assets/544280/1912431/0fa9000a-7d3a-11e3-8421-0bb7b275e928.png)
