### PR TITLE
Update CDN links to jQuery 1.11.0

### DIFF
--- a/themes/jquery/footer-mobile.php
+++ b/themes/jquery/footer-mobile.php
@@ -12,7 +12,7 @@
 				</div>
 				<div class="cdn">
 					<strong>CDN <em>JS</em></strong>
-					<input value="//code.jquery.com/jquery-1.10.2.min.js" readonly>
+					<input value="//code.jquery.com/jquery-1.11.0.min.js" readonly>
 				</div>
 				<div class="cdn">
 					<strong>CDN <em>JS</em></strong>

--- a/themes/jquery/footer-ui.php
+++ b/themes/jquery/footer-ui.php
@@ -12,7 +12,7 @@
 				</div>
 				<div class="cdn">
 					<strong>CDN <em>JS</em></strong>
-					<input value="//code.jquery.com/jquery-1.10.2.js" readonly>
+					<input value="//code.jquery.com/jquery-1.11.0.js" readonly>
 				</div>
 				<div class="cdn">
 					<strong>CDN <em>JS</em></strong>

--- a/themes/jquery/footer.php
+++ b/themes/jquery/footer.php
@@ -8,10 +8,10 @@
 				<h3><span>Quick Access</span></h3>
 				<div class="cdn">
 					<strong>CDN</strong>
-					<input value="//code.jquery.com/jquery-1.10.2.min.js" readonly>
+					<input value="//code.jquery.com/jquery-1.11.0.min.js" readonly>
 				</div>
 				<div class="download">
-					<strong><a href="http://jquery.com/download/">Download jQuery 1.10.2 →</a></strong>
+					<strong><a href="http://jquery.com/download/">Download jQuery 1.11.0 →</a></strong>
 				</div>
 				<ul class="footer-icon-links">
 					<li><a class="icon-github" href="http://github.com/jquery/jquery">GitHub <small>jQuery <br>Source</small></a></li>


### PR DESCRIPTION
CDN Quick Access Links are still pointing to jQuery v1.10.2.
