### PR TITLE
All Sites: Use natural sorting for terms

### DIFF
--- a/mu-plugins/jquery-filters.php
+++ b/mu-plugins/jquery-filters.php
@@ -90,3 +90,21 @@ add_filter( 'upload_dir', function( $upload_dir ) {
 
 	return $upload_dir;
 });
+
+add_filter( 'get_terms', function( $terms, $taxonomies, $args ) {
+	if ( !isset( $args[ 'orderby' ] ) || $args[ 'orderby' ] !== 'natural' ) {
+		return $terms;
+	}
+
+	$sortedTerms = array();
+	foreach( $terms as $term ) {
+		$sortedTerms[ $term->name ] = $term;
+	}
+	uksort( $sortedTerms, 'strnatcmp' );
+	
+	if ( strtolower( $args[ 'order' ] ) === 'desc' ) {
+		$sortedTerms = array_reverse( $sortedTerms );
+	}
+
+	return $sortedTerms;
+}, 20, 3 );

--- a/themes/jquery/sidebar.php
+++ b/themes/jquery/sidebar.php
@@ -7,6 +7,7 @@
 	<aside id="categories" class="widget">
 		<ul>
 			<?php wp_list_categories( array(
+				'orderby' => 'natural',
 				'depth' => 2,
 				'title_li' => '',
 				'current_category' => jq_post_category(),


### PR DESCRIPTION
Fixes gh-268

This makes things like sorting version numbers nicer, for categories such as "Deprecated 1.10" but it also makes "CSS" sort before "Callbacks Object" because of the casing.
