### PR TITLE
jquery.com: Fix white space on right side of website on mobile

### DIFF
--- a/themes/jquery.com/style.css
+++ b/themes/jquery.com/style.css
@@ -122,6 +122,7 @@ a,
 	width: 277px;
 	text-indent: -9999px;
 	display: block;
+	max-width: 100%;
 }
 
 @media only screen and (-webkit-device-pixel-ratio: 2) {


### PR DESCRIPTION
On the home page of jquery.com the try jQuery link extends off the right side of the
page causing white space. See before:
https://i.cloudup.com/vzCQyixCaX.PNG and after:
https://i.cloudup.com/P1M-8dagZa.PNG
