### PR TITLE
CSS: Use alpha transparency for code background

### DIFF
--- a/themes/jquery/css/base.css
+++ b/themes/jquery/css/base.css
@@ -246,7 +246,7 @@ pre, code {
 }
 code {
 	padding: 0 3px;
-	background-color: #eee;
+	background-color: rgba( 0, 0, 0, .1 );
 	border-radius: 3px;
 }
 pre code {


### PR DESCRIPTION
Code blocks looked terrible in notes.

before:
![solid background](http://cl.ly/image/461O3X1Q1z2c/Screen%20Shot%202014-07-17%20at%208.45.01%20PM.png)

after:
![alpha transparency](http://cl.ly/image/1b0p1Y0v1H08/Screen%20Shot%202014-07-17%20at%208.44.46%20PM.png)

Another option would be to specify `color` for `code`, but I think this works better.

(ignore the typo in the screenshots)
