### PR TITLE
Mu-plugins: Fix api version url re-write to handle cross site links

### DIFF
--- a/mu-plugins/api-sites/rewrite-old-api-links.php
+++ b/mu-plugins/api-sites/rewrite-old-api-links.php
@@ -13,7 +13,7 @@ if ( false === strpos( JQUERY_LIVE_SITE, '/' ) )
 list( , $subsite ) = explode( '/', JQUERY_LIVE_SITE, 2 );
 
 $callback = function( $content ) use ( $subsite ) {
-	$content = preg_replace( '~(href|src)=(["\'])/(?!\d+\.\d+/)~', '$1=$2/' . $subsite . '/', $content );
+	$content = preg_replace( '~(href|src)=(["\'])/(?!\d+\.\d+/)(?=/'.JQUERY_LIVE_DOMAIN.')~', '$1=$2/' . $subsite . '/', $content );
 	return $content;
 };
 


### PR DESCRIPTION
Currently all cross site protocol relative links fail on the mobile and ui api sites when on a previous version like ui 1.9 due to url re-writing for versions. This makes sure we don't re-write links except for on the current site. 
