### PR TITLE
Header: remove unescape call

### DIFF
--- a/themes/jquery/header.php
+++ b/themes/jquery/header.php
@@ -29,7 +29,7 @@
 	<script src="<?php echo get_template_directory_uri(); ?>/js/modernizr.custom.2.6.2.min.js"></script>
 
 	<script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-	<script>window.jQuery || document.write(unescape('%3Cscript src="<?php echo get_template_directory_uri(); ?>/js/jquery-1.9.1.min.js"%3E%3C/script%3E'))</script>
+	<script>window.jQuery || document.write('<script src="<?php echo get_template_directory_uri(); ?>/js/jquery-1.9.1.min.js"><\/script>')</script>
 
 	<script src="<?php echo get_template_directory_uri(); ?>/js/plugins.js"></script>
 	<script src="<?php echo get_template_directory_uri(); ?>/js/main.js"></script>


### PR DESCRIPTION
That `unescape()` isn't necessary. In h5bp it's removed too: https://github.com/h5bp/html5-boilerplate/commit/cada0b681a1ec1b31c7c832bd4bc2b5c4a5a278e
