### PR TITLE
learn.jquery.com: remove templating for contributors attributions

### DIFF
--- a/themes/learn.jquery.com/content-page.php
+++ b/themes/learn.jquery.com/content-page.php
@@ -44,27 +44,6 @@
 			<ul>
 				<li class="icon-calendar icon-large" title="Last Updated"><span><?php the_modified_time('F j, Y'); ?></span></li>
 			</ul>
-			<?php if ( get_post_meta( $post->ID, "contributors" ) ) : ?>
-				<?php $contributors = json_decode(get_post_meta( $post->ID, "contributors", true)) ?>
-				<h3>Contributors</h3>
-				<ul class="contributor-list">
-				<?php foreach ($contributors as $contrib) { ?>
-					<li>
-						<?php if ( isset( $contrib ->source ) ) : ?>
-							<a href="<?php echo $contrib->source ?>">
-						<?php endif ?>
-						<?php if ( isset( $contrib ->email ) ) : ?>
-							<?php echo get_avatar( $contrib->email, 24) ?>
-						<?php endif ?>
-						<?php echo $contrib->name ?>
-						<?php if ( isset( $contrib ->source ) ) : ?>
-							</a>
-						<?php endif ?>
-
-					</li>
-				<?php } ?>
-				</ul>
-			<?php endif; ?>
 		</aside>
 		<aside class="github-feedback six columns">
 			<h3>Suggestions, Problems, Feedback?</h3>

--- a/themes/learn.jquery.com/style.css
+++ b/themes/learn.jquery.com/style.css
@@ -196,29 +196,6 @@ a {
 	float: left;
 }
 
-.entry-meta aside.meta-details .contributor-list {
-	list-style-type: none;
-	margin: 0;
-}
-#content .entry-meta aside.meta-details .contributor-list li {
-	font-size: 14px;
-	line-height: 24px;
-	margin: 0 0 4px 0;
-	background: none;
-	padding-left: 0;
-}
-
-.entry-meta aside.meta-details .contributor-list li a {
-	text-decoration: none;
-}
-
-.entry-meta aside.meta-details .contributor-list li a:hover {
-	text-decoration: underline;
-}
-.entry-meta aside.meta-details .contributor-list li img {
-	vertical-align: middle;
-	margin-right: 4px;
-}
 .meta .feedback {
 	float: left;
 	display: block;


### PR DESCRIPTION
__Don't merge this yet, It must be merged the same time with a PR in the `learn.jquery.com` repo. Just open for review now.__

As discussed in https://github.com/jquery/learn.jquery.com/issues/602, this section is going to get replaced by a link to the Github contributor graphs.

Also: seems like my editor removed some trailing whitespace in the css file, don't care about it :beers: