### PR TITLE
Build: remove dates from copyright notice

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,4 @@
-Copyright 2011, 2014 jQuery Foundation and other contributors,
-https://jquery.org/
+Copyright jQuery Foundation and other contributors, https://jquery.org/
 
 This software consists of voluntary contributions made by many
 individuals. For exact contribution history, see the revision history

--- a/themes/jquery/css/base.css
+++ b/themes/jquery/css/base.css
@@ -1,4 +1,4 @@
-/*! Copyright 2014 jQuery Foundation and other contributors
+/*! Copyright jQuery Foundation and other contributors
  * Includes:
  * - normalize.css v1.0.1 | MIT License | git.io/normalize
  * - Font Awesome - http://fortawesome.github.com/Font-Awesome - CC BY 3.0


### PR DESCRIPTION
This removes the years from the copyright notices. These aren't needed.