### PR TITLE
learn.jquery.com: remove link to contribution guides

### DIFF
--- a/themes/jquery/menu-header.php
+++ b/themes/jquery/menu-header.php
@@ -28,7 +28,6 @@ function menu_header_learn_jquery_com() {
 	return array(
 		'http://learn.jquery.com' => 'Home',
 		'http://learn.jquery.com/about/' => 'About',
-		'http://learn.jquery.com/contributing/' => 'Contributing',
 		'http://learn.jquery.com/style-guide/' => 'Style Guide',
 	);
 }


### PR DESCRIPTION
In learn.jquery.com we still had a project-specific `contributing` page. As we'll delete that page and link up `contribute.jquery.org` instead, this shouldn't be in the header anymore.

Together with jquery/learn.jquery.com#634, this fixes https://github.com/jquery/learn.jquery.com/issues/554.
