### PR TITLE
learn.jquery.com: change highlighting links

### DIFF
--- a/themes/learn.jquery.com/sidebar.php
+++ b/themes/learn.jquery.com/sidebar.php
@@ -12,7 +12,7 @@
 			<ul>
 				<?php $chapters = learn_chapter_listing(); ?>
 				<?php while ( $chapters->have_posts() ) : $chapters->the_post(); ?>
-					<?php $is_active = ($active_post->ID == $chapters->post->ID) || ($active_post->post_parent == $chapters->post->ID); ?>
+					<?php $is_active = ($active_post->ID == $chapters->post->ID); ?>
 					<li <?php if ($is_active) { echo "class='active'"; } ?>>
 						<a href="<?php the_permalink(); ?>">
 							<?php if ( get_post_meta( $post->ID, "icon" ) ) : ?>
@@ -32,9 +32,12 @@
 								<ul class="sub-chapter">
 								<?php while ( $sub_chapters->have_posts() ) : $sub_chapters->the_post(); ?>
 									<?php if ( has_children( $post ) ) { ?>
-									<li><a href="<?php the_permalink(); ?>">
-										<?php the_title(); ?>
-									</a></li>
+									<?php $is_active = ($active_post->ID == $sub_chapters->post->ID) || ($active_post->post_parent == $sub_chapters->post->ID); ?>
+									<li <?php if ($is_active) { echo "class='active'"; } ?>>
+										<a href="<?php the_permalink(); ?>">
+											<?php the_title(); ?>
+										</a>
+									</li>
 									<?php } ?>
 								<?php endwhile; wp_reset_postdata(); ?>
 								</ul>

--- a/themes/learn.jquery.com/style.css
+++ b/themes/learn.jquery.com/style.css
@@ -82,13 +82,13 @@ a {
 
 }
 
-#sidebar #chapter-listing li.active a {
+#sidebar #chapter-listing li.active > a {
 	background: #212121;
 	color: #fff;
 	text-shadow: none;
 }
 
-#sidebar #chapter-listing li.active a i.icon-tasks {
+#sidebar #chapter-listing li.active > a i {
 	color: #fff;
 }
 


### PR DESCRIPTION
It is the incorrect selection active chapters in the sidebar in learn.jquery.com. For example, only `jQuery UI` should be highlighted on the page `jQuery UI`, without `Widget Factory` and `Using jQuery UI`. There is same situation in other links with subchapters (`Using jQuery Core` and `Code Organization`).

This PR fixes this problem.