### PR TITLE
contribute.jquery.org: Show CLA error details, if available

### DIFF
--- a/themes/contribute.jquery.org/cla-check.php
+++ b/themes/contribute.jquery.org/cla-check.php
@@ -110,7 +110,14 @@ function getProcessedPost( $data ) {
 function neglectedAuthors( $data ) {
 	$html = "<ul>\n";
 	foreach ( $data->data->neglectedAuthors as $author ) {
-		$html .= "<li>" . htmlspecialchars( "$author->name <$author->email>" ) . "</li>\n";
+		$html .= "<li>" . htmlspecialchars( "$author->name <$author->email>" );
+		if ( count( $author->errors ) ) {
+			$html .= ": ";
+			foreach( $author->errors as $error ) {
+				$html .= htmlspecialchars( " $error" );
+			}
+		}
+		$html .= "</li>\n";
 	}
 	$html .= "</ul>\n";
 	return $html;


### PR DESCRIPTION
This depends on the jquery-license changes that expose the error details.

Fixes jquery/jquery-license#17
Ref jquery/jquery-license#38

Actual error output:

![...](http://bassistance.de/i/cc28a2.png)

Compare to: http://contribute.jquery.org/CLA/status/?repo=globalize&sha=21b404d2c534dfb6b69c3cf1fdb0427082d147d2