### PR TITLE
Update sunrise and allow newer versions of WordPress to work

### DIFF
--- a/install.php
+++ b/install.php
@@ -34,7 +34,9 @@ function wp_install( $blog_title, $user_name, $user_email, $public, $deprecated 
 	install_network();
 	populate_network( 1, $domain, $user_email, 'jQuery Network', $base, false );
 
-	update_site_option( 'site_admins', array( $user->user_login ) );
+	delete_site_option( 'site_admins' );
+	add_site_option( 'site_admins', array( $user->user_login ) );
+
 	update_site_option( 'allowedthemes', array() );
 
 	$wpdb->insert( $wpdb->blogs, array( 'site_id' => 1, 'domain' => $domain, 'path' => $base, 'registered' => current_time( 'mysql' ) ) );

--- a/mu-plugins/jquery-filters.php
+++ b/mu-plugins/jquery-filters.php
@@ -113,5 +113,10 @@ add_filter( 'get_terms', function( $terms, $taxonomies, $args ) {
 add_filter( 'theme_root_uri', 'strip_https', 10, 1 );
 add_filter( 'clean_url', 'strip_https', 11, 1 );
 function strip_https($url) {
+	// WordPress core updates need a protocol.
+	if ( 'downloads.wordpress.org' === parse_url( $url, PHP_URL_HOST ) ) {
+		return $url;
+	}
+
 	return preg_replace( '/^https?:/', '', $url );
 }

--- a/sunrise.php
+++ b/sunrise.php
@@ -1,12 +1,23 @@
 <?php
+// This is a single network configuration and the network is defined in config.php
+if ( defined( 'DOMAIN_CURRENT_SITE' ) && defined( 'PATH_CURRENT_SITE' ) ) {
+	$current_site = new stdClass;
+	$current_site->id = defined( 'SITE_ID_CURRENT_SITE' ) ? SITE_ID_CURRENT_SITE : 1;
+	$current_site->blog_id = defined( 'BLOG_ID_CURRENT_SITE' ) ? BLOG_ID_CURRENT_SITE : 1;
+	$current_site->cookie_domain = defined( 'COOKIE_DOMAIN' ) ? COOKIE_DOMAIN : '.jquery.com';
+	$current_site->domain = DOMAIN_CURRENT_SITE;
+	$current_site->path = PATH_CURRENT_SITE;
+	$current_site->site_name = 'jQuery';
+}
 
 if ( isset( $blog_id ) ) {
-	$current_site = wpmu_current_site();
-	if ( ! is_object( $current_site ) )
-		$current_site = new stdClass;
-	if ( ! isset( $current_site->site_name ) )
-		$current_site->site_name = 'jQuery';
 	$current_blog = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $wpdb->blogs WHERE blog_id = %d", $blog_id ) );
+
+	// If for some reason this became a multi-network configuration, populate the site's network.
+	if ( is_object( $current_blog ) && $current_blog->site_id != $current_site->id ) {
+		$current_site = $wpdb->get_row( $wpdb->prepare( "SELECT * from $wpdb->site WHERE id = %d LIMIT 0,1", $current_blog->site_id ) );
+		$current_site->site_name = 'jQuery';
+	}
 
 	// Can't find the site in the DB:
 	if ( ! is_object( $current_blog ) ) {


### PR DESCRIPTION
Addresses #303:

* Update how a network is defined by assuming only one network exists and is defined in the configuration.
* Watch for the likely not to happen scenario where a second network is installed.
* Catch a case where the `site_admins` network option may not be properly set during installation locally.
* Allow `downloads.wordpress.org` URLs to survive the protocol relative filter so that local updates will work nicely. 

This takes a slightly different approach from @Ipstenu in #378 as there are quite a few gotchas hanging out there when running this outside of the Vagrant environment and/or when installing and upgrading.

There's probably room for future improvement, especially once the Vagrant box has been updated to use a newer version of WordPress by default. We could then rewrite a bit more and make a few more assumptions about the environment. This should work as a pretty good stop-gap in the meantime.

I've tested:
* New install of the environment in WordPress 3.8.1
* Upgrade from WordPress 3.8.1 to 4.3.1
* New install of the environment in WordPress 4.3