### PR TITLE
Pointed the Vagrantfile to a new box with Wordpress 4.4

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,10 +7,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # use the config key as the vm identifier
   config.vm.box = "jquery-wp-content"
-  config.vm.box_download_checksum_type = "sha256"
-  config.vm.box_download_checksum = "3182bc50668e86022e7d50bc8c096774b49de40cfaffc77f4fad75ca6cf83d3d"
 
-  config.vm.box_url = "http://boxes.jquery.com/jquery-wp-content.box"
+  config.vm.box_url = "http://boxes.jquery.com/jquery-wp-content-4.4.box"
 
   config.vm.synced_folder "./", "/var/www/wordpress/jquery-wp-content"
 
@@ -24,7 +22,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.provider "virtualbox" do |v|
     # make sure that the name makes sense when seen in the vbox GUI
-    v.name = "jQuery Sites"
+    v.name = "jQuerySites"
 
     # Be nice to our users.
     v.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]


### PR DESCRIPTION
Also removed the space from the 'v.name' param, this makes it easier to manage via the command line.
