### PR TITLE
codeorigin.jquery.com: Add PEP link to menu

### DIFF
--- a/themes/jquery/menu-header.php
+++ b/themes/jquery/menu-header.php
@@ -39,7 +39,8 @@ function menu_header_codeorigin_jquery_com() {
 		'/ui/' => 'jQuery UI',
 		'/mobile/' => 'jQuery Mobile',
 		'/color/' => 'jQuery Color',
-		'/qunit/' => 'QUnit'
+		'/qunit/' => 'QUnit',
+		'/pep/' => 'PEP'
 	);
 }
 


### PR DESCRIPTION
I think that it would be helpful to add [PEP](https://code.jquery.com/pep/) link into menu.