### PR TITLE
Add grunt channels to sidebar

### DIFF
--- a/themes/irc.jquery.org/sidebar.php
+++ b/themes/irc.jquery.org/sidebar.php
@@ -6,6 +6,8 @@
 			<li><a href="/%23globalize/">#globalize</a></li>
 			<li><a href="/%23esprima/">#esprima</a></li>
 			<li><a href="/%23esprima-meeting/">#esprima-meeting</a></li>
+			<li><a href="/%23grunt/">#grunt</a></li>
+			<li><a href="/%23grunt-dev/">#grunt-dev</a></li>
 			<li><a href="/%23jquery/">#jquery</a></li>
 			<li><a href="/%23jquery-content/">#jquery-content</a></li>
 			<li><a href="/%23jquery-dev/">#jquery-dev</a></li>


### PR DESCRIPTION
I'm still unclear on why there is a [robots.txt that excludes the logs](https://github.com/dmethvin/jquery-wp-content/blob/aeefd86d4e834ba01b813646a0563b8e4ce7a928/themes/irc.jquery.org/robots.txt) but since PEP isn't excluding logs I figured I would give it a try without. 