### PR TITLE
Added jQuery Gems to footer of jQuery.com website

### DIFF
--- a/themes/jquery/footer.php
+++ b/themes/jquery/footer.php
@@ -28,6 +28,13 @@
 							<cite>Cody Lindley</cite>
 						</a>
 					</li>
+					<li>
+						<a href="https://www.amazon.com/jQuery-Gems-JavaScript-beginners-programming-ebook/dp/B00GW7Q9DW?tag=j0a1a-20">
+							<img src="<?php echo get_template_directory_uri(); ?>/content/books/jquery-gems.jpg" alt="jQuery Gems by Greg Sidelnikov" width="92" height="114">
+							jQuery Gems
+							<cite>Greg Sidelnikov</cite>
+						</a>
+					</li>
 				</ul>
 			</div>
 		</div>


### PR DESCRIPTION
I am the author of jQuery Gems.

Over the years, it has gained reputation as a useful jQuery Reference book.

Would it be possible to include it here?

In addition it would also need the cover image file "jquery-gems.jpg" at following location:

<?php echo get_template_directory_uri(); ?>/content/books/jquery-gems.jpg