### PR TITLE
Header: Remove "Try jQuery"

### DIFF
--- a/themes/jquery/header.php
+++ b/themes/jquery/header.php
@@ -80,7 +80,6 @@
 					<li class="dropdown"><a href="https://jquery.org/support/">Support</a>
 						<ul>
 							<li><a href="https://learn.jquery.com/">Learning Center</a></li>
-							<li><a href="http://try.jquery.com/">Try jQuery</a></li>
 							<li><a href="https://irc.jquery.org/">IRC/Chat</a></li>
 							<li><a href="https://forum.jquery.com/">Forums</a></li>
 							<li><a href="https://stackoverflow.com/tags/jquery/info">Stack Overflow</a></li>


### PR DESCRIPTION
Try jQuery is no longer being offered. This commit works alongside
https://github.com/jquery/jquery.com/commit/9ac15a47a696d2c21a59cf025d4f5b4408bec80c

Closes https://github.com/jquery/jquery.com/issues/176.

~I would like to sign the CLA per the contributing guidelines, but I can't figure out how to sign the CLA at http://contribute.jquery.org/cla (which redirects to https://js.foundation/CLA for me).~