### PR TITLE
api.jquery.com: Fix 404 Not Found for donate img

### DIFF
--- a/themes/jquery/header.php
+++ b/themes/jquery/header.php
@@ -107,7 +107,7 @@
 
 		<aside>
 			<div id="broadcast">
-				<a href="https://js.foundation/about/donate" title="Support the JS Foundation"><img src="jquery-wp-content/themes/jquery/content/donate.png" title="Support the JS Foundation" alt="Support the JS Foundation" border="0" width="400" height="100"></a>
+				<a href="https://js.foundation/about/donate" title="Support the JS Foundation"><img src="/jquery-wp-content/themes/jquery/content/donate.png" title="Support the JS Foundation" alt="Support the JS Foundation" border="0" width="400" height="100"></a>
 			</div>
 		</aside>
 	</div>


### PR DESCRIPTION
Any subpage or directory is currently yielding a 404 Not Found error for
the donate image.

Example: http://api.jquery.com/jQuery/

/cc @kborchers 