### PR TITLE
All: Add Algolia's DocSearch to UI/Mobile/QUnit website searches

### DIFF
--- a/themes/jquery/footer-mobile.php
+++ b/themes/jquery/footer-mobile.php
@@ -9,7 +9,7 @@
 
 <?php wp_footer(); ?>
 	<!-- at the end of the BODY -->
-	<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"  onload="docsearch({apiKey: '207328b0f1c18555c9021d05157dd651',
+	<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"  onload="document.querySelector('input[name=\'s\']') && docsearch({apiKey: '207328b0f1c18555c9021d05157dd651',
 		indexName: 'jquerymobile',
 		inputSelector: 'input[name=\'s\']',
 		debug: true // Set debug to true if you want to inspect the dropdown

--- a/themes/jquery/footer-mobile.php
+++ b/themes/jquery/footer-mobile.php
@@ -8,6 +8,12 @@
 </footer>
 
 <?php wp_footer(); ?>
+	<!-- at the end of the BODY -->
+	<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"  onload="docsearch({apiKey: '207328b0f1c18555c9021d05157dd651',
+		indexName: 'jquerymobile',
+		inputSelector: 'input[name=\'s\']',
+		debug: true // Set debug to true if you want to inspect the dropdown
+	})" async></script>
 
 </body>
 </html>

--- a/themes/jquery/footer-qunit.php
+++ b/themes/jquery/footer-qunit.php
@@ -36,6 +36,12 @@
 </footer>
 
 <?php wp_footer(); ?>
+	<!-- at the end of the BODY -->
+	<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"  onload="docsearch({apiKey: 'e0955983cecd6e4582d3a91908d4d766',
+		indexName: 'qunitjs',
+		inputSelector: 'input[name=\'s\']',
+		debug: true // Set debug to true if you want to inspect the dropdown
+	})" async></script>
 
 </body>
 </html>

--- a/themes/jquery/footer-qunit.php
+++ b/themes/jquery/footer-qunit.php
@@ -37,7 +37,7 @@
 
 <?php wp_footer(); ?>
 	<!-- at the end of the BODY -->
-	<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"  onload="docsearch({apiKey: 'e0955983cecd6e4582d3a91908d4d766',
+	<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"  onload="document.querySelector('input[name=\'s\']') && docsearch({apiKey: 'e0955983cecd6e4582d3a91908d4d766',
 		indexName: 'qunitjs',
 		inputSelector: 'input[name=\'s\']',
 		debug: true // Set debug to true if you want to inspect the dropdown

--- a/themes/jquery/footer-ui.php
+++ b/themes/jquery/footer-ui.php
@@ -36,6 +36,12 @@
 </footer>
 
 <?php wp_footer(); ?>
+	<!-- at the end of the BODY -->
+	<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"  onload="docsearch({apiKey: '2fce35e56784bbb48c78d105739190c2',
+		indexName: 'jqueryui',
+		inputSelector: 'input[name=\'s\']',
+		debug: true // Set debug to true if you want to inspect the dropdown
+	})" async></script>
 
 </body>
 </html>

--- a/themes/jquery/footer-ui.php
+++ b/themes/jquery/footer-ui.php
@@ -37,7 +37,7 @@
 
 <?php wp_footer(); ?>
 	<!-- at the end of the BODY -->
-	<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"  onload="docsearch({apiKey: '2fce35e56784bbb48c78d105739190c2',
+	<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"  onload="document.querySelector('input[name=\'s\']') && docsearch({apiKey: '2fce35e56784bbb48c78d105739190c2',
 		indexName: 'jqueryui',
 		inputSelector: 'input[name=\'s\']',
 		debug: true // Set debug to true if you want to inspect the dropdown

--- a/themes/jquery/footer.php
+++ b/themes/jquery/footer.php
@@ -38,7 +38,7 @@
 
 <?php wp_footer(); ?>
 	<!-- at the end of the BODY -->
-	<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"  onload="docsearch({apiKey: '3cfde9aca378c8aab554d5bf1b23489b',
+	<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"  onload="document.querySelector('input[name=\'s\']') && docsearch({apiKey: '3cfde9aca378c8aab554d5bf1b23489b',
 		indexName: 'jquery',
 		inputSelector: 'input[name=\'s\']',
 		debug: true // Set debug to true if you want to inspect the dropdown


### PR DESCRIPTION
This PR will add DocSearch to all other documentation websites as https://jquery.com/. It will allow an user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

If there is no result, pressing enter will enable the legacy search.

Follow #416