### PR TITLE
jquery: Add boilerplate language & links to the footer

### DIFF
--- a/themes/jquery/footer-bottom.php
+++ b/themes/jquery/footer-bottom.php
@@ -50,8 +50,7 @@
 		<li><a class="icon-<?php echo $link[ 'icon' ]; ?>" href="<?php echo $link[ 'url' ]; ?>"><?php echo $title; ?></a></li>
 	<?php endforeach ?></ul>
 	<p class="copyright">
-		Copyright <?php echo date('Y'); ?> <a href="https://jquery.org/team/">The jQuery Foundation</a>.
-		<a href="https://jquery.org/license/">jQuery License</a>
+		Copyright <?php echo date('Y'); ?> <a href="https://openjsf.org/">OpenJS Foundation</a> and jQuery contributors. All rights reserved. See <a href="https://jquery.org/license/">jQuery License</a> for more information. The <a href="https://openjsf.org/">OpenJS Foundation</a> has registered trademarks and uses trademarks. For a list of trademarks of the <a href="https://openjsf.org/">OpenJS Foundation</a>, please see our <a href="https://trademark-policy.openjsf.org/">Trademark Policy</a> and <a href="https://trademark-list.openjsf.org/">Trademark List</a>. Trademarks and logos not indicated on the <a href="https://trademark-list.openjsf.org/">list of OpenJS Foundation trademarks</a> are trademarks™ or registered® trademarks of their respective holders. Use of them does not imply any affiliation with or endorsement by them. OpenJS Foundation <a href="https://terms-of-use.openjsf.org/">Terms of Use</a>, <a href="https://privacy-policy.openjsf.org/">Privacy</a>, and <a href="https://www.linuxfoundation.org/cookies">Cookie</a> Policies also apply.
 		<span class="sponsor-line"><a href="https://www.digitalocean.com" class="do-link">Web hosting by Digital Ocean</a> | <a href="https://www.stackpath.com" class="sp-link">CDN by StackPath</a></span>
 	</p>
 </div>


### PR DESCRIPTION
Will close #427. This PR adds the boilerplate language and updated legal / policy links to the existing layout. I think we want to probably restyle this a bit but I am not a designer and would defer to others for how to address the layout: 

<img width="1193" alt="Screen Shot 2020-12-09 at 11 23 09 PM" src="https://user-images.githubusercontent.com/1355039/101721555-3da97600-3a76-11eb-921d-235f126b38e4.png">
