### PR TITLE
jquery: Make code-listing line numbers unselectable

### DIFF
--- a/themes/jquery/css/base.css
+++ b/themes/jquery/css/base.css
@@ -3793,6 +3793,8 @@ pre .diff .hljs-comment {
 .syntaxhighlighter table td.gutter .line {
 	text-align: right !important;
 	padding: 0 0.5em 0 1em !important;
+	user-select: none;
+	-webkit-user-select: none;
 }
 .syntaxhighlighter table td.code .line {
 	padding: 0 0.5em !important;

--- a/themes/jquery/css/base.css
+++ b/themes/jquery/css/base.css
@@ -3793,8 +3793,9 @@ pre .diff .hljs-comment {
 .syntaxhighlighter table td.gutter .line {
 	text-align: right !important;
 	padding: 0 0.5em 0 1em !important;
-	user-select: none;
 	-webkit-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
 }
 .syntaxhighlighter table td.code .line {
 	padding: 0 0.5em !important;


### PR DESCRIPTION
This PR uses the [well-supported](https://caniuse.com/mdn-css_properties_user-select)<sup>1</sup> `user-select: none` CSS property on the line number gutter in syntaxhighlighter code blocks, to prevent accidental inclusion when copy-pasting the contained code.

### Notes
1. while `user-select: none` has broad browser support, both Safari versions do require its use as the vendor-prefixed `-webkit-user-select` (also included in the PR changes).

<s>(CLA Note: As I mentioned in jquery/contribute.jquery.org#149, the CLA links across the documentation are currently linking to an OpenJSF page with no CLA in evidence. I have not signed the CLA simply because I can't find any way _**to**_ sign it.)</s> Never mind, the bot's link worked.