### PR TITLE
All: add option filter to prevent local homepage redirects

### DIFF
--- a/mu-plugins/jquery-filters.php
+++ b/mu-plugins/jquery-filters.php
@@ -120,3 +120,13 @@ function strip_https($url) {
 
 	return preg_replace( '/^https?:/', '', $url );
 }
+
+// Production databases set the home values in corresponding site options tables.
+// However, sites that use jquery-static-index.php cause index pages
+// to redirect to live sites in local development. This filter does not
+// prevent the redirect, but changes the redirect to the local site.
+if (JQUERY_STAGING && JQUERY_STAGING_PREFIX && JQUERY_LIVE_SITE) {
+	add_filter( 'option_home', function( $value ) {
+		return str_replace( '//' . JQUERY_LIVE_SITE, '//' . JQUERY_STAGING_PREFIX . JQUERY_LIVE_SITE, $value );
+	} );
+}


### PR DESCRIPTION
This adds a filter to prevent local redirects to live sites, specifically local.jquery.com to jquery.com and local.jqueryui.com to jqueryui.com. The culprit turned out to be a combination of wordpress redirecting indexes classified as "page" and the jquery-static-index.php plugin used on those sites. Thanks to @Krinkle for his help figuring this out.