### PR TITLE
All: upgrade main jQuery to 3.7.0

### DIFF
--- a/themes/jquery/header.php
+++ b/themes/jquery/header.php
@@ -25,7 +25,7 @@
 
 	<script src="<?php echo get_template_directory_uri(); ?>/js/modernizr.custom.2.8.3.min.js"></script>
 
-	<script src="https://code.jquery.com/jquery-1.11.3.js"></script>
+	<script src="https://code.jquery.com/jquery-3.7.0.js"></script>
 
 	<script src="<?php echo get_template_directory_uri(); ?>/js/plugins.js"></script>
 	<script src="<?php echo get_template_directory_uri(); ?>/js/main.js"></script>


### PR DESCRIPTION
Upgrade jQuery to 3.7.0 for all jquery-wp-content sites. All sites have been tested locally.

It's possible I may have missed something, so I'll double check each site after deployment.

Fixes gh-400