### PR TITLE
jquery: add jQuery Team link to main header

### DIFF
--- a/themes/jquery/header.php
+++ b/themes/jquery/header.php
@@ -75,6 +75,7 @@
 						<ul>
 							<li><a href="https://openjsf.org/about/join/">Join</a></li>
 							<li><a href="https://openjsf.org/about/members/">Members</a></li>
+							<li><a href="https://jquery.com/team">jQuery Team</a></li>
 							<li><a href="https://openjsf.org/about/governance/">Governance</a></li>
 							<li><a href="https://code-of-conduct.openjsf.org/">Conduct</a></li>
 							<li><a href="https://openjsf.org/about/project-funding-opportunities/">Donate</a></li>


### PR DESCRIPTION
Added here:

<img width="444" alt="Screenshot 2024-01-19 at 7 49 14 PM" src="https://github.com/jquery/jquery-wp-content/assets/192451/d1775ea6-8c6a-48c5-bfea-e076edd80eab">

Links to https://jquery.com/team