### PR TITLE
jquery: Add the `js` class, remove the `no-js` one

### DIFF
--- a/themes/jquery/js/main.js
+++ b/themes/jquery/js/main.js
@@ -1,3 +1,6 @@
+// Some CSS depends on the `js` class.
+$( "html" ).addClass( "js" ).removeClass( "no-js" );
+
 /*
  * All sites
  */


### PR DESCRIPTION
This used to be done by Modernizr until its removal in 08f27c14ffc14c158b25e190cfa00125fb79c0d3. Some sites apply different styling for JS-disabled environments; one such example is the jQuery UI Download Builder which expands all Themeroller knobs sections in the no-JS mode.