### PR TITLE
api.jqueryui.com: Prepare for jQuery UI 1.14

### DIFF
--- a/sites.php
+++ b/sites.php
@@ -341,6 +341,22 @@ function jquery_sites() {
 				'jquery_twitter_link' => 'https://twitter.com/jqueryui',
 			),
 		),
+		'api.jqueryui.com/1.14' => array(
+			'cookie_domain' => '.jqueryui.com',
+			'options' => array(
+				'blogname' => 'jQuery UI 1.14 Documentation',
+				'stylesheet' => 'api.jqueryui.com',
+				'active_plugins' => array(
+					'jquery-api-category-listing.php',
+					'jquery-api-versioned-links.php',
+				),
+				'jquery_body_class' => 'jquery-ui',
+				'jquery_logo_link'=> 'https://jqueryui.com/',
+				'jquery_typesense_key' => 'Zh8mMgohXECel9wjPwqT7lekLSG3OCgz',
+				'jquery_typesense_collection' => 'jqueryui_com',
+				'jquery_twitter_link' => 'https://twitter.com/jqueryui',
+			),
+		),
 	);
 
 	return $sites;

--- a/themes/api.jqueryui.com/functions.php
+++ b/themes/api.jqueryui.com/functions.php
@@ -3,12 +3,13 @@
 function jq_ui_api_versions() {
 	// Must be listed with current stable first
 	return array(
-		"1.13" => "1.8 and newer",
-		"1.12" => "1.7 and newer",
-		"1.11" => "1.6 and newer",
-		"1.10" => "1.6 and newer",
-		"1.9" => "1.6 and newer",
-		"1.8" => "1.3.2 and newer",
+		"1.14" => "latest versions of jQuery 1.x, 2.x, 3.x & 4.x; see <a href=\"https://jqueryui.com/changelog/\">the changelogs of a specific release</a> for more detailed support information",
+		"1.13" => "jQuery 1.8 and newer",
+		"1.12" => "jQuery 1.7 and newer",
+		"1.11" => "jQuery 1.6 and newer",
+		"1.10" => "jQuery 1.6 and newer",
+		"1.9" => "jQuery 1.6 and newer",
+		"1.8" => "jQuery 1.3.2 and newer",
 	);
 }
 

--- a/themes/api.jqueryui.com/index.php
+++ b/themes/api.jqueryui.com/index.php
@@ -50,7 +50,7 @@
 			category from the sidebar.</p>
 
 		<p>jQuery UI <?php echo $thisVersion; ?>
-			supports jQuery <?php echo $versions[ $thisVersion ]; ?>.</p>
+			supports <?php echo $versions[ $thisVersion ]; ?>.</p>
 
 		<hr>
 

--- a/themes/releases.jquery.com/page.php
+++ b/themes/releases.jquery.com/page.php
@@ -1,8 +1,8 @@
 <?php
-wp_enqueue_style('jquery-ui', 'https://code.jquery.com/ui/1.13.2/themes/ui-lightness/jquery-ui.css');
+wp_enqueue_style('jquery-ui', 'https://code.jquery.com/ui/1.13.3/themes/ui-lightness/jquery-ui.css');
 wp_enqueue_style('sri-modal', get_template_directory_uri() . '/css/sri-modal.css');
 
-wp_enqueue_script('jquery-ui', 'https://code.jquery.com/ui/1.13.2/jquery-ui.min.js');
+wp_enqueue_script('jquery-ui', 'https://code.jquery.com/ui/1.13.3/jquery-ui.min.js');
 wp_enqueue_script('clipboard-polyfill', get_template_directory_uri() . '/js/clipboard-polyfill.js');
 wp_enqueue_script('sri-modal', get_template_directory_uri() . '/js/sri-modal.js');
 ?>


### PR DESCRIPTION
Also, update jQuery UI used on releases.jquery.com from 1.13.2 to 1.13.3.