### PR TITLE
All: add Content-Security-Policy-Report-Only header to all wordpress sites

### DIFF
--- a/themes/api.jquery.com/functions.php
+++ b/themes/api.jquery.com/functions.php
@@ -1,0 +1,8 @@
+<?php
+
+// Allow inline scripts and styles in API demos
+add_filter( 'jq_content_security_policy', function ( $policy ) {
+	$policy[ 'script-src' ] = "'self' 'unsafe-inline' code.jquery.com";
+	$policy[ 'style-src' ] = "'self' 'unsafe-inline'";
+	return $policy;
+} );

--- a/themes/api.jquerymobile.com/functions.php
+++ b/themes/api.jquerymobile.com/functions.php
@@ -28,3 +28,10 @@ function jq_mobile_api_version_current() {
 		$thisVersion[ 1 ] :
 		jq_mobile_api_version_latest();
 }
+
+// Allow inline scripts and styles in API demos
+add_filter( 'jq_content_security_policy', function ( $policy ) {
+	$policy[ 'script-src' ] = "'self' 'unsafe-inline' code.jquery.com";
+	$policy[ 'style-src' ] = "'self' 'unsafe-inline'";
+	return $policy;
+} );

--- a/themes/api.jqueryui.com/functions.php
+++ b/themes/api.jqueryui.com/functions.php
@@ -24,3 +24,10 @@ function jq_ui_api_version_current() {
 		$thisVersion[ 1 ] :
 		jq_ui_api_version_latest();
 }
+
+// Allow inline scripts and styles in API demos
+add_filter( 'jq_content_security_policy', function ( $policy ) {
+	$policy[ 'script-src' ] = "'self' 'unsafe-inline' code.jquery.com";
+	$policy[ 'style-src' ] = "'self' 'unsafe-inline'";
+	return $policy;
+} );

--- a/themes/jquery/functions.php
+++ b/themes/jquery/functions.php
@@ -256,6 +256,9 @@ add_filter( 'body_class', function ( $classes ) {
  * Content Security Policy
  */
 function jq_content_security_policy() {
+	if ( !JQUERY_STAGING ) {
+		return;
+	}
 	$nonce = bin2hex( random_bytes( 8 ) );
 	$policy = array(
 		'default-src' => "'self'",
@@ -284,7 +287,7 @@ function jq_content_security_policy() {
 		$policy_string .= $key . ' ' . $value . '; ';
 	}
 
-	header( 'Content-Security-Policy: ' . $policy_string );
+	header( 'Content-Security-Policy-Report-Only: ' . $policy_string );
 }
 
 add_action( 'send_headers', 'jq_content_security_policy' );

--- a/themes/jquery/functions.php
+++ b/themes/jquery/functions.php
@@ -260,6 +260,7 @@ function jq_content_security_policy() {
 		return;
 	}
 	$nonce = bin2hex( random_bytes( 8 ) );
+	$report_url = 'https://csp-report-api.openjs-foundation.workers.dev/';
 	$policy = array(
 		'default-src' => "'self'",
 		'script-src' => "'self' 'nonce-$nonce' code.jquery.com",
@@ -277,7 +278,10 @@ function jq_content_security_policy() {
 		'frame-ancestors' => "'none'",
 		'base-uri' => "'self'",
 		'block-all-mixed-content' => '',
-		'report-to' => 'https://csp-report-api.openjs-foundation.workers.dev/',
+		'report-to' => 'csp-endpoint',
+		// Add report-uri for Firefox, which
+		// does not yet support report-to
+		'report-uri' => $report_url,
 	);
 
 	$policy = apply_filters( 'jq_content_security_policy', $policy );
@@ -287,6 +291,7 @@ function jq_content_security_policy() {
 		$policy_string .= $key . ' ' . $value . '; ';
 	}
 
+	header( 'Reporting-Endpoints: csp-endpoint="' . $report_url . '"' );
 	header( 'Content-Security-Policy-Report-Only: ' . $policy_string );
 }
 

--- a/themes/jquery/functions.php
+++ b/themes/jquery/functions.php
@@ -255,8 +255,8 @@ add_filter( 'body_class', function ( $classes ) {
 /**
  * Content Security Policy
  */
-function jq_content_security_policy() {
-	$nonce = wp_create_nonce( JQUERY_LIVE_SITE );
+function jq_content_security_policy( $headers ) {
+	$nonce = bin2hex( random_bytes( 8 ) );
 	$policy = array(
 		'default-src' => "'self'",
 		'script-src' => "'self' 'nonce-$nonce' code.jquery.com",
@@ -285,5 +285,9 @@ function jq_content_security_policy() {
 		$policy_string .= $key . ' ' . $value . '; ';
 	}
 
-	header( 'Content-Security-Policy-Report-Only: ' . $policy_string );
+	$headers[] = 'Content-Security-Policy: ' . $policy_string;
+
+	return $headers;
 }
+
+add_filter( 'wp_headers', 'jq_content_security_policy' );

--- a/themes/jquery/functions.php
+++ b/themes/jquery/functions.php
@@ -260,9 +260,8 @@ function jq_content_security_policy() {
 	$policy = array(
 		'default-src' => "'self'",
 		'script-src' => "'self' 'nonce-$nonce' code.jquery.com",
-		// The SHA is for the inline style from typesense
-		// 'unsafe-hashes' is required in order to use hashes in style-src
-		'style-src' => "'self' 'nonce-$nonce' 'sha256-biLFinpqYMtWHmXfkA1BPeCY0/fNt46SAZ+BBk5YUog=' 'unsafe-hashes'",
+		// The nonce is here so inline scripts can be used in the theme
+		'style-src' => "'self' 'nonce-$nonce'",
 		// data: SVG images are used in typesense
 		'img-src' => "'self' data:",
 		'connect-src' => "'self' typesense.jquery.com",

--- a/themes/jquery/functions.php
+++ b/themes/jquery/functions.php
@@ -275,7 +275,7 @@ function jq_content_security_policy() {
 		'frame-ancestors' => "'none'",
 		'base-uri' => "'self'",
 		'block-all-mixed-content' => '',
-		'report-uri' => 'https://csp-report-api.openjs-foundation.workers.dev/',
+		'report-to' => 'https://csp-report-api.openjs-foundation.workers.dev/',
 	);
 
 	$policy = apply_filters( 'jq_content_security_policy', $policy );

--- a/themes/jquery/functions.php
+++ b/themes/jquery/functions.php
@@ -255,7 +255,7 @@ add_filter( 'body_class', function ( $classes ) {
 /**
  * Content Security Policy
  */
-function jq_content_security_policy( $headers ) {
+function jq_content_security_policy() {
 	$nonce = bin2hex( random_bytes( 8 ) );
 	$policy = array(
 		'default-src' => "'self'",
@@ -285,9 +285,7 @@ function jq_content_security_policy( $headers ) {
 		$policy_string .= $key . ' ' . $value . '; ';
 	}
 
-	$headers[] = 'Content-Security-Policy: ' . $policy_string;
-
-	return $headers;
+	header( 'Content-Security-Policy: ' . $policy_string );
 }
 
-add_filter( 'wp_headers', 'jq_content_security_policy' );
+add_action( 'send_headers', 'jq_content_security_policy' );

--- a/themes/jquery/functions.php
+++ b/themes/jquery/functions.php
@@ -251,3 +251,39 @@ add_filter( 'body_class', function ( $classes ) {
 
 	return $classes;
 } );
+
+/**
+ * Content Security Policy
+ */
+function jq_content_security_policy() {
+	$nonce = wp_create_nonce( JQUERY_LIVE_SITE );
+	$policy = array(
+		'default-src' => "'self'",
+		'script-src' => "'self' 'nonce-$nonce' code.jquery.com",
+		// The SHA is for the inline style from typesense
+		// 'unsafe-hashes' is required in order to use hashes in style-src
+		'style-src' => "'self' 'nonce-$nonce' 'sha256-biLFinpqYMtWHmXfkA1BPeCY0/fNt46SAZ+BBk5YUog=' 'unsafe-hashes'",
+		// data: SVG images are used in typesense
+		'img-src' => "'self' data:",
+		'connect-src' => "'self' typesense.jquery.com",
+		'font-src' => "'self'",
+		'object-src' => "'none'",
+		'media-src' => "'self'",
+		'frame-src' => "'self'",
+		'child-src' => "'self'",
+		'form-action' => "'self'",
+		'frame-ancestors' => "'none'",
+		'base-uri' => "'self'",
+		'block-all-mixed-content' => '',
+		'report-uri' => 'https://csp-report-api.openjs-foundation.workers.dev/',
+	);
+
+	$policy = apply_filters( 'jq_content_security_policy', $policy );
+
+	$policy_string = '';
+	foreach ( $policy as $key => $value ) {
+		$policy_string .= $key . ' ' . $value . '; ';
+	}
+
+	header( 'Content-Security-Policy-Report-Only: ' . $policy_string );
+}

--- a/themes/jquery/header.php
+++ b/themes/jquery/header.php
@@ -1,4 +1,3 @@
-<?php jq_content_security_policy() ?>
 <!doctype html>
 <html class="no-js" <?php language_attributes(); ?>>
 <head>

--- a/themes/jquery/header.php
+++ b/themes/jquery/header.php
@@ -1,3 +1,4 @@
+<?php jq_content_security_policy() ?>
 <!doctype html>
 <html class="no-js" <?php language_attributes(); ?>>
 <head>
@@ -5,7 +6,6 @@
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 
 	<title><?php
-		global $page, $paged;
 		wp_title( '|', true, 'right' );
 		bloginfo( 'name' );
 		$site_description = get_bloginfo( 'description', 'display' );


### PR DESCRIPTION
Ref jquery/infrastructure-puppet#54
Ref jquery/infrastructure-puppet#57

This adds a filter that the API sites can override to allow for inline scripts and styles only in API demos.

I'm thinking we can use this in combination with a header set in infrastructure-puppet for non-wordpress sites.