### PR TITLE
jquery: Fix links to pages on the OpenJS Foundation site

### DIFF
--- a/themes/jquery/header.php
+++ b/themes/jquery/header.php
@@ -77,12 +77,12 @@
 					</li>
 					<li class="dropdown"><a href="https://openjsf.org/">OpenJS Foundation</a>
 						<ul>
-							<li><a href="https://openjsf.org/about/join/">Join</a></li>
-							<li><a href="https://openjsf.org/about/members/">Members</a></li>
+							<li><a href="https://openjsf.org/join">Join</a></li>
+							<li><a href="https://openjsf.org/members">Members</a></li>
 							<li><a href="https://jquery.com/team">jQuery Team</a></li>
-							<li><a href="https://openjsf.org/about/governance/">Governance</a></li>
+							<li><a href="https://openjsf.org/governance">Governance</a></li>
 							<li><a href="https://code-of-conduct.openjsf.org/">Conduct</a></li>
-							<li><a href="https://openjsf.org/about/project-funding-opportunities/">Donate</a></li>
+							<li><a href="https://openjsf.org/projects">Projects</a></li>
 						</ul>
 					</li>
 				</ul>


### PR DESCRIPTION
1. Some of these links started redirecting to different locations; update accordingly.
2. The website titled "Donate" and having "project-funding-opportunities" in the URL now redirects to the list of projects; change the name as well.

This should fix the failing spider check on api.jquery.com PRs.