### PR TITLE
Local: ensure template assets use the correct port locally

### DIFF
--- a/plugins/jquery-filters.php
+++ b/plugins/jquery-filters.php
@@ -35,6 +35,16 @@ foreach ( $options as $option => $value ) {
 }
 unset( $sites, $options, $option );
 
+// Ensure that the local port is used for template assets, if it exists.
+add_filter( 'theme_root_uri', function( $value ) {
+	if ( JQUERY_STAGING === 'local' ) {
+		// Don't specify http vs https here, as the site may be accessed via either.
+		$siteurl = '//' . strtr( JQUERY_STAGING_FORMAT, [ '%s' => JQUERY_LIVE_SITE ] );
+		$value = $siteurl . '/wp-content/themes';
+	}
+	return $value;
+});
+
 // Remove misc links from <head> on non-blog sites
 if ( !get_option( 'jquery_is_blog' ) ) {
 	remove_action( 'wp_head', 'feed_links', 2 );

--- a/plugins/jquery-filters.php
+++ b/plugins/jquery-filters.php
@@ -37,6 +37,9 @@ unset( $sites, $options, $option );
 
 // Ensure that the local port is used for template assets, if it exists.
 add_filter( 'theme_root_uri', function( $value ) {
+	// All environment variables are set either in the local wp-config.php or via puppet.
+	// Staging sites set JQUERY_STAGING to the boolean `true` instead of 'local'.
+	// Production sites set it to false.
 	if ( JQUERY_STAGING === 'local' ) {
 		// Don't specify http vs https here, as the site may be accessed via either.
 		$siteurl = '//' . strtr( JQUERY_STAGING_FORMAT, [ '%s' => JQUERY_LIVE_SITE ] );


### PR DESCRIPTION
While debugging local setups with Andre, I noticed that when I changed port, the template assets continued to be served from port 80. This filter ensures that `theme_root_uri` includes the local port number, even after a database is populated with a portless siteurl, without the need to alter the database.

For whatever reason, Andre didn't have this issue when switching ports, but I did, and I couldn't tell you why this isn't always necessary.