### PR TITLE
Add HeroDevs support.

### DIFF
--- a/themes/api.jquery.com/category.php
+++ b/themes/api.jquery.com/category.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * The template for displaying Category Archive pages.
+ */
+
+get_header(); ?>
+
+
+<div class="content-right twelve columns">
+	<div id="content">
+	<?php if ( have_posts() ) : ?>
+
+		<header class="page-header">
+			<h1 class="page-title"><?php
+				printf( __( 'Category: %s', 'twentyeleven' ), '<span>' . single_cat_title( '', false ) . '</span>' );
+			?></h1>
+			<hr>
+			<?php
+
+			$current_url = home_url(add_query_arg(null, null));
+
+			if (jq_is_version_deprecated($current_url)) {
+
+			?>
+
+			<div id="support-warning-box" class="warning"><svg width="20" height="20" viewBox="0 0 24 24">
+				<circle cx="12" cy="12" r="10" fill="none" stroke="black" stroke-width="2" />
+				<text x="50%" y="57%" dominant-baseline="middle" text-anchor="middle">i</text>
+				</svg>&nbsp;&nbsp;This version is End-of-Life. Read more about support options&nbsp;<a href="https://jquery.com/support/">here</a>.
+			</div>
+
+		  <?php
+
+			}
+
+				$category_description = category_description();
+				if ( ! empty( $category_description ) ) {
+					echo apply_filters( 'category_archive_meta',
+						'<div class="category-archive-meta">' . $category_description . '</div>' );
+				}
+			?>
+
+		</header>
+
+		<?php
+			while ( have_posts() ) : the_post();
+				get_template_part( 'content', 'listing' );
+			endwhile;
+		?>
+
+		<?php echo jq_content_nav(); ?>
+
+	<?php else : ?>
+
+		<article id="post-0" class="post no-results not-found">
+			<header class="entry-header">
+				<h1 class="entry-title"><?php _e( 'Nothing Found', 'twentyeleven' ); ?></h1>
+			</header>
+
+			<div class="entry-content">
+				<p><?php _e( 'Apologies, but no results were found for the requested archive.', 'twentyeleven' ); ?></p>
+			</div>
+		</article>
+
+	<?php endif; ?>
+	</div>
+
+	<?php get_sidebar(); ?>
+</div>
+
+<?php get_footer(); ?>

--- a/themes/api.jquery.com/style.css
+++ b/themes/api.jquery.com/style.css
@@ -34,3 +34,14 @@ a {
 	margin-top: 0;
 	padding-left: 1em;
 }
+
+/* Support warning at top of API pages */
+
+#support-warning-box {
+	padding-top: 8px;
+	padding-left: 8px;
+	padding-bottom: 8px;
+	display: flex;
+	position: relative;
+	z-index: 1;
+}

--- a/themes/jquery/css/base.css
+++ b/themes/jquery/css/base.css
@@ -881,6 +881,24 @@ iframe {
 	margin: 0;
 }
 
+/* Support message at top of page.
+   ========================================================================== */
+
+#support-message {
+	display: flex;
+	justify-content: center;
+	background-color: #dddddd;
+	padding: 4px 4px;
+	font-size: 15px;
+}
+#support-message span {
+	text-align: center;
+	padding-left: 20px;
+	padding-right: 20px;
+}
+#support-message span a {
+	color: #222;
+}
 
 /* Global Nav
    ========================================================================== */

--- a/themes/jquery/functions.php
+++ b/themes/jquery/functions.php
@@ -252,6 +252,46 @@ add_filter( 'body_class', function ( $classes ) {
 	return $classes;
 } );
 
+/*
+ * Determine if the current page is for a deprecated version of jQuery.
+ * We are concened with two URL structures:
+ *   category/deprecated/deprecated-1.3/
+ *   category/version/1.9/
+ *
+ * @returns int True or false
+ */
+function jq_is_version_deprecated($url) {
+  $parsedUrl = parse_url($url);
+  $path = $parsedUrl['path'];
+  $segments = explode('/', trim($path, '/'));
+
+  $versionLessThan3 = false;
+
+  if (count($segments) > 2) {
+		switch (strtolower($segments[1])) {
+			// Check first URL structure:
+			// category/deprecated/deprecated-1.3/
+			case 'deprecated':
+				// Obtain the version number from the third slug.
+				$version = floatval(substr($segments[2], 11));
+
+				if ($version < 3) $versionLessThan3 = true;
+
+				break;
+
+			// Check second URL structure:
+			// category/version/1.9/
+			case 'version':
+				$version = floatval($segments[2]);
+
+				if ($version < 3)  $versionLessThan3 = true;
+
+				break;
+			}
+	}
+  return $versionLessThan3;
+}
+
 /**
  * Content Security Policy
  */
@@ -296,3 +336,4 @@ function jq_content_security_policy() {
 }
 
 add_action( 'send_headers', 'jq_content_security_policy' );
+

--- a/themes/jquery/header.php
+++ b/themes/jquery/header.php
@@ -39,6 +39,14 @@
 </head>
 <body <?php body_class(); ?>>
 
+<?php if (is_front_page()) { ?>
+
+<div id="support-message" class="support-message">
+	<span style="">jQuery 4 is currently in beta. Soon jQuery 3 will reach EOL along with versions 1 and 2. Learn more about our&nbsp;<a href="https://jquery.com/support/">Version&nbsp;Support</a>.</span>
+</div>
+
+<?php } ?>
+
 <header>
 	<section id="global-nav">
 		<nav>

--- a/themes/jquery/menu-header.php
+++ b/themes/jquery/menu-header.php
@@ -13,6 +13,7 @@ function menu_header_jquery_com() {
 		'https://blog.jquery.com/' => 'Blog',
 		'https://plugins.jquery.com/' => 'Plugins',
 		'https://jquery.com/browser-support/' => 'Browser Support',
+		'https://jquery.com/support/' => 'Version Support',
 	);
 }
 


### PR DESCRIPTION
This supports https://github.com/jquery/jquery-wp-content/issues/462.

Within this, please find:

1. add status message top of screen on homepage
2. add Support menu item to navigation bar
3. change text on Download button; add a link below the button
4. add warning box to API pages (via a new category.php file)
5. add styling for the above.

Please examine and confirm the logic for the deprecated APIs...I read the instructions to mean "show the warning box" on the deprecated pages IF the version is EOL. Happy to change this if I got that wrong.

If a version is deprecated (the version is lower than 3.0), it will look like this:

![screenshot_3382](https://github.com/user-attachments/assets/ecdb4979-c352-4ffd-a6ca-01901f50848a)

The status bar looks like below and appears only on the home page of jquery.com:
![screenshot_3383](https://github.com/user-attachments/assets/310cbec3-ded5-4af7-8591-8d9da0dd39f1)

The button text and link below look like this:
![screenshot_3384](https://github.com/user-attachments/assets/c1ab3165-7947-4f84-85f8-6d8d556b45b7)



