### PR TITLE
HeroDevs support

### DIFF
--- a/themes/api.jquery.com/style.css
+++ b/themes/api.jquery.com/style.css
@@ -34,3 +34,13 @@ a {
 	margin-top: 0;
 	padding-left: 1em;
 }
+
+/* Version support warning at top of API pages */
+
+#version-support-warning {
+	display: flex;
+	align-items: center;
+	gap: 0.5em;
+	padding: 0.5em 0 0.5em 0.5em;
+	line-height: 1.2;
+}

--- a/themes/jquery.com/style.css
+++ b/themes/jquery.com/style.css
@@ -54,8 +54,7 @@ a,
 	transform: rotate(6.28rad);
 }
 
-.download-options,
-.download-help {
+#banner-secondary .download-main .download-options {
 	margin-top: 1em;
 }
 #banner-secondary .download-options a {
@@ -95,6 +94,47 @@ a,
 }
 #content #banner-secondary .download-main .support-notice {
 	font-size: 12px;
+}
+
+/* New download button */
+#banner-secondary > .download {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	margin-bottom: 1em;
+}
+.download-button-content {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	gap: 0.5em;
+}
+.download-button-content .download-icon {
+	background: url('i/download.png') no-repeat 0 5px / 100% 100%;
+	width: 35px;
+	height: 35px;
+	display: inline-block;
+	flex-shrink: 0;
+}
+.download-button-content .download-message {
+	flex-grow: 1;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	text-align: center;
+	gap: 0.25em;
+}
+.download-button-content .download-message .download-version {
+	font-size: 0.7em;
+}
+.download-options .support-notice {
+	margin: 0.5em 0;
+	color: #ccc;
+}
+@media only screen and (max-width: 767px) {
+	#banner-secondary .download {
+		align-items: center;
+	}
 }
 
 .resources {

--- a/themes/jquery/css/base.css
+++ b/themes/jquery/css/base.css
@@ -103,6 +103,14 @@ body {
   font-weight: normal;
   font-style: normal;
 }
+[class^="icon-"]:before,
+[class*=" icon-"]:before {
+	font-size: 1.2em;
+  text-decoration: inherit;
+  display: inline-block;
+  speak: none;
+}
+.icon-info-sign:before { content: "\f05a"; }
 
 /* ==========================================================================
    Links
@@ -881,6 +889,19 @@ iframe {
 	margin: 0;
 }
 
+/* Support message at top of page.
+   ========================================================================== */
+
+#banner {
+	text-align: center;
+	background-color: #dddddd;
+	padding: 0.25em 1.25em;
+	color: #333; /* jQuery Black */
+}
+
+#banner a:hover {
+	text-decoration: none;
+}
 
 /* Global Nav
    ========================================================================== */
@@ -1396,8 +1417,7 @@ pre b {
 
 #content img.full,
 #content img.left,
-#content img.right,
-#banner img.full {
+#content img.right {
 	box-shadow: 0 0 5px 1px rgba(0, 0, 0, 0.20);
 }
 
@@ -1458,10 +1478,6 @@ pre b {
 	overflow: hidden;
 	box-shadow: 0 0 5px 1px rgba(0, 0, 0, 0.20);
 	margin-bottom: 20px;
-}
-
-#portfolio.media #banner .embed {
-	margin-bottom: 40px;
 }
 
 .embed iframe,

--- a/themes/jquery/functions.jquery.php
+++ b/themes/jquery/functions.jquery.php
@@ -183,3 +183,14 @@ function jq_search_get_provider() {
 	}
 	return '';
 }
+
+/**
+ * Get a checksum of styles used in the header
+ */
+function jq_css_checksum() {
+	$base = get_template_directory() . '/css/base.css';
+	$typesense = get_template_directory() . '/lib/typesense-minibar/typesense-minibar.css';
+	$styles = get_stylesheet_directory() . '/style.css';
+
+	return md5( filemtime( $base ) . filemtime( $typesense ) . filemtime( $styles ) );
+}

--- a/themes/jquery/header.php
+++ b/themes/jquery/header.php
@@ -39,6 +39,12 @@
 </head>
 <body <?php body_class(); ?>>
 
+<?php if ( is_front_page() && defined( "JQUERY_BANNER" ) ) : ?>
+	<div id="banner">
+		<?php echo JQUERY_BANNER ?>
+	</div>
+<?php endif; ?>
+
 <header>
 	<section id="global-nav">
 		<nav>

--- a/themes/jquery/header.php
+++ b/themes/jquery/header.php
@@ -17,16 +17,16 @@
 	<meta name="viewport" content="width=device-width">
 
 	<link rel="shortcut icon" href="<?php echo get_stylesheet_directory_uri(); ?>/i/favicon.ico">
-	<link rel="stylesheet" href="<?php echo get_template_directory_uri(); ?>/lib/typesense-minibar/typesense-minibar.css?v=1.3.4">
-	<link rel="stylesheet" href="<?php echo get_template_directory_uri(); ?>/css/base.css?v=17">
-	<link rel="stylesheet" href="<?php bloginfo( 'stylesheet_url' ); ?>?v=8">
+	<link rel="stylesheet" href="<?php echo get_template_directory_uri(); ?>/lib/typesense-minibar/typesense-minibar.css?v=<?php echo jq_css_checksum(); ?>">
+	<link rel="stylesheet" href="<?php echo get_template_directory_uri(); ?>/css/base.css?v=<?php echo jq_css_checksum(); ?>">
+	<link rel="stylesheet" href="<?php bloginfo( 'stylesheet_url' ); ?>?v=<?php echo jq_css_checksum(); ?>">
 
 	<script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
 	<script src="<?php echo get_template_directory_uri(); ?>/js/main.js"></script>
 <?php
 	if ( jq_search_get_provider() === 'typesense' ) :
 ?>
-	<script defer type="module" src="<?php echo get_template_directory_uri(); ?>/lib/typesense-minibar/typesense-minibar.js?v=1.3.4"></script>
+	<script defer type="module" src="<?php echo get_template_directory_uri(); ?>/lib/typesense-minibar/typesense-minibar.js?v=<?php echo jq_css_checksum(); ?>"></script>
 <?php
 	endif;
 

--- a/themes/jquery/menu-header.php
+++ b/themes/jquery/menu-header.php
@@ -13,6 +13,7 @@ function menu_header_jquery_com() {
 		'https://blog.jquery.com/' => 'Blog',
 		'https://plugins.jquery.com/' => 'Plugins',
 		'https://jquery.com/browser-support/' => 'Browser Support',
+		'https://jquery.com/support/' => 'Version Support',
 	);
 }
 


### PR DESCRIPTION
I made some modifications to #467, including:

- generalized banner for future use
- set banner message explicitly in post meta (jquery.com's index lives in its repo, so we'll set that there). I set api.jquery.com's banner in its theme's index page. Before, the banner was showing on the homepage of all jQuery wordpress sites (e.g. jquerymobile.com), but we only want it to show on site specific to jQuery core (i.e. jquery.com and api.jquery.com).
- adjusted styles for version support warnings. used the fontawesome icon we are already loading instead of new svg.

Ref gh-467
Closes gh-462

See companion PRs for [jquery.com](https://github.com/jquery/jquery.com/pull/246) and [api.jquery.com](https://github.com/jquery/api.jquery.com/pull/1251).