### PR TITLE
All: enable CSP report header on production sites

### DIFF
--- a/themes/jquery/functions.php
+++ b/themes/jquery/functions.php
@@ -256,9 +256,6 @@ add_filter( 'body_class', function ( $classes ) {
  * Content Security Policy
  */
 function jq_content_security_policy() {
-	if ( !JQUERY_STAGING ) {
-		return;
-	}
 	$nonce = bin2hex( random_bytes( 8 ) );
 	$report_url = 'https://csp-report-api.openjs-foundation.workers.dev/';
 	$policy = array(


### PR DESCRIPTION
Ref https://github.com/jquery/infrastructure-puppet/issues/54

I just noticed a CSP violation on all wordpress content sites. It seems any sites generated with Wordpress 6.7 have an added style tag:

```html
<style>img:is([sizes="auto" i], [sizes^="auto," i]) { contain-intrinsic-size: 3000px 1500px }</style>
```

I'm actually fine not adding an exception for this as it doesn't seem to make a difference on our sites.