### PR TITLE
jqueryui.com: add CSP exceptions for jQuery UI themeroller

### DIFF
--- a/themes/api.jquery.com/functions.php
+++ b/themes/api.jquery.com/functions.php
@@ -1,8 +1,10 @@
 <?php
 
 // Allow inline scripts and styles in API demos
+// Allow flickr script and images on https://api.jquery.com/jQuery.getJSON/
 add_filter( 'jq_content_security_policy', function ( $policy ) {
-	$policy[ 'script-src' ] = "'self' 'unsafe-inline' code.jquery.com";
+	$policy[ 'script-src' ] = "'self' 'unsafe-inline' code.jquery.com api.flickr.com";
 	$policy[ 'style-src' ] = "'self' 'unsafe-inline' code.jquery.com";
+	$policy[ 'img-src' ] = "'self' data: code.jquery.com live.staticflickr.com";
 	return $policy;
 } );

--- a/themes/jquery/css/sri-modal.css
+++ b/themes/jquery/css/sri-modal.css
@@ -35,7 +35,9 @@
 	right: 28px;
 }
 
-.sri-modal .ui-icon-closethick {
+.sri-modal .ui-icon-closethick,
+.sri-modal .ui-button:hover .ui-icon-closethick,
+.sri-modal .ui-button:active .ui-icon-closethick {
 	background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAAclBMVEUAAADMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMxg1ZvWAAAAJXRSTlMAAQIDBAUGCQsNDhQWGSg4g4uUoKOoq62vsLW8wMrO2tzk5ujxm/5xbwAAAGxJREFUGBmNwVcWgkAQRcFHg4FgzjomZu7+t+hpRv6p0iS7byPJTs+5BluIjewML5O7A3F1AdJMrgpkqVVWBVxqNVriNhrZDRdrZXYl62sNjkBaB6Cv5PaQOpUB3iZXHFInqXx8FvozDQpN8gNoXAtiMhPWmQAAAABJRU5ErkJggg==) 0 0;
 }
 

--- a/themes/jqueryui.com/functions.php
+++ b/themes/jqueryui.com/functions.php
@@ -1,3 +1,12 @@
 <?php
 
 require_once __DIR__ . '/functions.content.php';
+
+// Allow inline scripts on https://jqueryui.com/themeroller/
+// Load styles from download.jqueryui.com on https://jqueryui.com/themeroller/
+// Load images from download.jqueryui.com on https://jqueryui.com/themeroller/
+add_filter( 'jq_content_security_policy', function ( $policy ) {
+	$policy[ 'style-src' ] = "'self' 'unsafe-inline' code.jquery.com download.jqueryui.com";
+	$policy[ 'img-src' ] = "'self' data: code.jquery.com download.jqueryui.com";
+	return $policy;
+} );


### PR DESCRIPTION
Mostly inline styles, with some styles and images loaded from download.jqueryui.com. See console at https://jqueryui.com/themeroller

- fixed an issue with the icon set for hover/active on the close button in the sri-modal at https://releases.jquery.com.
- added an exception for https://api.jquery.com/jQuery.getJSON, which uses the flickr api.

Ref https://github.com/jquery/infrastructure-puppet/issues/54