### PR TITLE
All: switch to enforced CSP header

### DIFF
--- a/themes/jquery/functions.php
+++ b/themes/jquery/functions.php
@@ -289,7 +289,7 @@ function jq_content_security_policy() {
 	}
 
 	header( 'Reporting-Endpoints: csp-endpoint="' . $report_url . '"' );
-	header( 'Content-Security-Policy-Report-Only: ' . $policy_string );
+	header( 'Content-Security-Policy: ' . $policy_string );
 }
 
 add_action( 'send_headers', 'jq_content_security_policy' );


### PR DESCRIPTION
Ref https://github.com/jquery/infrastructure-puppet/issues/54

I've addressed all the legitimate reports I could find in the csp logs. I think we can switch to the enforced header and continue watching the logs for anything I may have missed.

The only remaining report headers will be on the blog sites (once we fix the issue with them not showing up).