### PR TITLE
All: add CSP exceptions for wordpress admins

### DIFF
--- a/themes/jquery/functions.php
+++ b/themes/jquery/functions.php
@@ -264,14 +264,12 @@ function jq_content_security_policy() {
 		// The nonce is here so inline scripts can be used in the theme
 		'style-src' => "'self' 'nonce-$nonce' code.jquery.com",
 		// data: SVG images are used in typesense
-		'img-src' => "'self' data: code.jquery.com",
+		// Allow gravatars in wordpress admins
+		'img-src' => "'self' data: secure.gravatar.com code.jquery.com",
 		'connect-src' => "'self' typesense.jquery.com",
-		'font-src' => "'self'",
+		// Allow data fonts for the wordpress admins
+		'font-src' => "'self' data:",
 		'object-src' => "'none'",
-		'media-src' => "'self'",
-		'frame-src' => "'self'",
-		'child-src' => "'self'",
-		'form-action' => "'self'",
 		'frame-ancestors' => "'none'",
 		'base-uri' => "'self'",
 		'block-all-mixed-content' => '',


### PR DESCRIPTION
- when the blogs are switched to use this repo's jquery theme, the theme will need to allow for data: images and fonts. It still doesn't need to add exceptions for typekit as the fonts will be self-hosted.
- Also removed some redundant declarations. Anything not specified falls back to `default-src`, so setting `self` again isn't necessary.

Ref https://github.com/jquery/blog.jquery.com-theme/pull/12