### PR TITLE
Updating "Also in" link styles for better usability

### DIFF
--- a/themes/jquery/css/base.css
+++ b/themes/jquery/css/base.css
@@ -2042,11 +2042,6 @@ footer .books li a cite {
 	border-radius: 5px;
 }
 
-.listing #content .entry-meta .category a {
-	color: #0769ad;
-	text-decoration: underline;
-}
-
 .pagination {
 	text-align: center;
 	margin-top: 2em;

--- a/themes/jquery/css/base.css
+++ b/themes/jquery/css/base.css
@@ -1970,7 +1970,7 @@ footer .books li a cite {
 
 .entry-meta,
 .entry-posted {
-	color: #999;
+	color: #666;
 	font-size: 12px;
 }
 
@@ -2043,8 +2043,8 @@ footer .books li a cite {
 }
 
 .listing #content .entry-meta .category a {
-	color: #888;
-	text-decoration: none;
+	color: #0769ad;
+	text-decoration: underline;
 }
 
 .pagination {


### PR DESCRIPTION
As said by @sschmitz1414 in the api.jquery.com issue [Usability Error - Links](https://github.com/jquery/api.jquery.com/issues/1222).

> The "Also in" section in the list of Methods in the API Documentation as seen below can be a usability error. It is not clear that they are links due to being grey and not blue, they have no underline even when you hover on them, and it isn't clear where one link ends and another begins (for example Manipulate and Class Attribute are separate links even though the share the same "button" or border.

This PR aims to fix that by adding a blue color and the underline to the individual links, alongside increasing the visibility of the "Also in" section by darkening the text color a bit.

Resulting in the following look:
![opera_nZILNuAmRI](https://github.com/user-attachments/assets/3cd6b0ae-b499-4cc2-bb82-83ae5fa8edde)


Related to/Fixes api.jquery.com issue [#1222](https://github.com/jquery/api.jquery.com/issues/1222)