### PR TITLE
jquery: Address link text overflow issue on meetings.jquery.org

### DIFF
--- a/themes/jquery/menu-header.php
+++ b/themes/jquery/menu-header.php
@@ -64,7 +64,7 @@ function menu_header_jqueryui_com() {
 
 function menu_header_jquery_org() {
 	return array(
-		'https://jquery.com/' => 'Home',
+		'https://jquery.org/' => 'Home',
 		'https://meetings.jquery.org/' => 'Meetings',
 		'https://jquery.org/team/' => 'Team',
 		'https://brand.jquery.org/' => 'Brand Guide',


### PR DESCRIPTION
1.Attempted fixed an issue where hyperlink text in the category logs of meetings.jquery.org would overflow on mobile devices.
<img width="361" height="666" alt="F Y_Q15TRMTXCB6$61SSB_Y" src="https://github.com/user-attachments/assets/bf6e8678-45bf-45fc-b9db-5c64a8dcc9a1" />
@mgol @timmywil 